### PR TITLE
Fixed consecutive requests issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.iml
+.idea
+concept-search-api

--- a/client.go
+++ b/client.go
@@ -28,7 +28,7 @@ func newElasticClient(accessKey string, secretKey string, endpoint *string, regi
 		HTTPClient: &http.Client{
 			Timeout: 60 * time.Second,
 			Transport: &http.Transport{
-				MaxIdleConnsPerHost: 100,
+				MaxIdleConnsPerHost: 30,
 				Dial: (&net.Dialer{
 					KeepAlive: 30 * time.Second,
 				}).Dial,
@@ -42,6 +42,6 @@ func newElasticClient(accessKey string, secretKey string, endpoint *string, regi
 		elastic.SetScheme("https"),
 		elastic.SetHttpClient(signingClient),
 		elastic.SetSniff(false), //needs to be disabled due to EAS behavior.
-		//elastic.SetMaxRetries(3),
+		elastic.SetMaxRetries(3),
 	)
 }

--- a/client.go
+++ b/client.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	awsauth "github.com/smartystreets/go-aws-auth"
+	"gopkg.in/olivere/elastic.v3"
+	"net"
+	"net/http"
+	"time"
+)
+
+type AWSSigningTransport struct {
+	HTTPClient  *http.Client
+	Credentials awsauth.Credentials
+}
+
+// RoundTrip implementation
+func (a AWSSigningTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return a.HTTPClient.Do(awsauth.Sign4(req, a.Credentials))
+}
+
+func newElasticClient(accessKey string, secretKey string, endpoint *string, region *string) (*elastic.Client, error) {
+
+	signingTransport := AWSSigningTransport{
+		Credentials: awsauth.Credentials{
+			AccessKeyID:     accessKey,
+			SecretAccessKey: secretKey,
+		},
+		HTTPClient: &http.Client{
+			Timeout: 60 * time.Second,
+			Transport: &http.Transport{
+				MaxIdleConnsPerHost: 100,
+				Dial: (&net.Dialer{
+					KeepAlive: 30 * time.Second,
+				}).Dial,
+			},
+		},
+	}
+	signingClient := &http.Client{Transport: http.RoundTripper(signingTransport)}
+
+	return elastic.NewClient(
+		elastic.SetURL(*endpoint),
+		elastic.SetScheme("https"),
+		elastic.SetHttpClient(signingClient),
+		elastic.SetSniff(false), //needs to be disabled due to EAS behavior.
+		//elastic.SetMaxRetries(3),
+	)
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/Financial-Times/http-handlers-go/httphandlers"
+	log "github.com/Sirupsen/logrus"
+	"github.com/gorilla/mux"
+	"github.com/jawher/mow.cli"
+	"github.com/rcrowley/go-metrics"
+)
+
+func main() {
+	app := cli.App("concept-search-api", "API for searching concepts")
+	port := app.String(cli.StringOpt{
+		Name:   "port",
+		Value:  "8080",
+		Desc:   "Port to listen on",
+		EnvVar: "PORT",
+	})
+	accessKey := app.String(cli.StringOpt{
+		Name:   "aws-access-key",
+		Desc:   "AWS ACCES KEY",
+		EnvVar: "AWS_ACCESS_KEY_ID",
+	})
+	secretKey := app.String(cli.StringOpt{
+		Name:   "aws-secret-access-key",
+		Desc:   "AWS SECRET ACCES KEY",
+		EnvVar: "AWS_SECRET_ACCESS_KEY",
+	})
+	esEndpoint := app.String(cli.StringOpt{
+		Name:   "elasticsearch-endpoint",
+		Value:  "search-concept-search-mvp-k2vkgwhfgjv63nu6jvortpggha.eu-west-1.es.amazonaws.com",
+		Desc:   "AES endpoint",
+		EnvVar: "ELASTICSEARCH_ENDPOINT",
+	})
+	esRegion := app.String(cli.StringOpt{
+		Name:   "elasticsearch-region",
+		Value:  "eu-west-1",
+		Desc:   "AES region",
+		EnvVar: "ELASTICSEARCH_REGION",
+	})
+	esIndex := app.String(cli.StringOpt{
+		Name:   "elasticsearch-index",
+		Value:  "concept",
+		Desc:   "Elasticsearch index",
+		EnvVar: "ELASTICSEARCH_INDEX",
+	})
+	app.Action = func() {
+
+		accessConfig := esAccessConfig{
+			accessKey:  *accessKey,
+			secretKey:  *secretKey,
+			esEndpoint: *esEndpoint,
+			esRegion:   *esRegion,
+		}
+
+		elasticReader, err := NewESSearcherService(&accessConfig, *esIndex)
+
+		if err != nil {
+			log.Errorf("Concept search API failed to start: %v\n", err)
+		}
+
+		servicesRouter := mux.NewRouter()
+		var monitoringRouter http.Handler = servicesRouter
+		monitoringRouter = httphandlers.TransactionAwareRequestLoggingHandler(log.StandardLogger(), monitoringRouter)
+		monitoringRouter = httphandlers.HTTPMetricsHandler(metrics.DefaultRegistry, monitoringRouter)
+
+		http.HandleFunc("/_search", elasticReader.SearchConcept)
+		http.Handle("/", monitoringRouter)
+
+		if err := http.ListenAndServe(":"+*port, nil); err != nil {
+			log.Fatalf("Unable to start: %v", err)
+		}
+	}
+
+	log.SetLevel(log.InfoLevel)
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Errorf("App could not start, error=[%s]\n", err)
+		return
+	}
+}

--- a/model.go
+++ b/model.go
@@ -1,0 +1,15 @@
+package main
+
+type searchCriteria struct {
+	Term string `json:"term"`
+}
+
+type concept struct {
+	Id         string   `json:"id"`
+	ApiUrl     string   `json:"apiUrl"`
+	PrefLabel  string   `json:"prefLabel"`
+	Types      []string `json:"types"`
+	DirectType string   `json:"directType"`
+	Aliases    []string `json:"aliases,omitempty"`
+	Score      float64  `json:"score,omitempty"`
+}

--- a/service.go
+++ b/service.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"gopkg.in/olivere/elastic.v3"
+	"net/http"
+	"strconv"
+)
+
+type esSearcherService struct {
+	elasticClient *elastic.Client
+	indexName     string
+}
+
+type esAccessConfig struct {
+	accessKey  string
+	secretKey  string
+	esEndpoint string
+	esRegion   string
+}
+
+func NewESSearcherService(accessConfig *esAccessConfig, indexName string) (*esSearcherService, error) {
+	elasticClient, err := newElasticClient(accessConfig.accessKey, accessConfig.secretKey, &accessConfig.esEndpoint, &accessConfig.esRegion)
+	if err != nil {
+		return &esSearcherService{}, fmt.Errorf("Creating elasticsearch client failed with error=[%v]\n", err)
+	}
+
+	elasticSearcher := esSearcherService{elasticClient: elasticClient, indexName: indexName}
+
+	return &elasticSearcher, nil
+}
+
+func (service *esSearcherService) SearchConcept(writer http.ResponseWriter, request *http.Request) {
+
+	if service.elasticClient == nil {
+		log.Errorf("Elasticsearch client is not created.")
+		writer.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	var criteria searchCriteria
+	decoder := json.NewDecoder(request.Body)
+	err := decoder.Decode(&criteria)
+
+	if err != nil {
+		log.Errorf("There was an error parsing the search request: %s", err.Error())
+		writer.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	defer request.Body.Close()
+
+	query := elastic.NewMultiMatchQuery(criteria.Term, "prefLabel.raw", "aliases.raw", "prefLabel", "aliases").Type("most_fields")
+	searchResult, err := service.elasticClient.Search().
+		Index(service.indexName).
+		Query(query).
+		Size(50).
+		Do()
+
+	if err != nil {
+		log.Errorf("There was an error executing the query on ES: %s", err.Error())
+		writer.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if searchResult.Hits.TotalHits > 0 {
+		writer.Header().Add("Content-Type", "application/json")
+		searchedConcepts := getSearchedConcepts(searchResult, isScoreIncluded(request))
+		encoder := json.NewEncoder(writer)
+		encoder.Encode(&searchedConcepts)
+	} else {
+		writer.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func getSearchedConcepts(searchResult *elastic.SearchResult, isScoreIncluded bool) []concept {
+	var searchedConcepts []concept
+	for _, hit := range searchResult.Hits.Hits {
+		var concept concept
+		err := json.Unmarshal(*hit.Source, &concept)
+		if err != nil {
+			log.Errorf("Unable to unmarshall concept, error=[%s]\n", err)
+		} else {
+			if isScoreIncluded {
+				score := *hit.Score
+				concept.Score = score
+			}
+			searchedConcepts = append(searchedConcepts, concept)
+		}
+	}
+	return searchedConcepts
+}
+
+func isScoreIncluded(request *http.Request) bool {
+	queryParam := request.URL.Query().Get("include_score")
+	includeScore, err := strconv.ParseBool(queryParam)
+	if err != nil {
+		return false
+	}
+	return includeScore
+}


### PR DESCRIPTION
Added a version of the Concept Search API that contain a bug in which if consecutive requests were performed in a short span the second one failed.

Fixed the aforementioned bug by tweaking the HTTP client that connects to the Amazon ES domain. 