### PR TITLE
Feature/all by type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor/*/
 concept-search-api
 coverage.html
 coverage.json
+/.project

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.4
+FROM alpine:3.5
 
 COPY . /concept-search-api/
 
-RUN apk --update add bash git bzr go ca-certificates \
+RUN apk --update add bash git bzr go libc-dev ca-certificates \
   && export GOPATH=/gopath \
   && REPO_PATH="github.com/Financial-Times/concept-search-api" \
   && mkdir -p $GOPATH/src/${REPO_PATH} \

--- a/circle.yml
+++ b/circle.yml
@@ -1,27 +1,33 @@
+machine:
+  environment:
+    GOPATH: "${HOME}/.go_workspace:/usr/local/go_workspace:${HOME}/.go_project"
+    GO_PROJECT_PATH: "${HOME}/.go_project/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+
+checkout:
+  post:
+    - mkdir -p $(dirname ${GO_PROJECT_PATH})
+    - ln -fs $HOME/$CIRCLE_PROJECT_REPONAME $GO_PROJECT_PATH
+
 dependencies:
   pre:
-    - mkdir -p $HOME/.go_project/src/github.com/$CIRCLE_PROJECT_USERNAME
-    - ln -fs $HOME/$CIRCLE_PROJECT_REPONAME $HOME/.go_project/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
-    - |
-      echo 'export GOPATH=$GOPATH:$HOME/.go_project' >> ~/.circlerc
-    - go get github.com/axw/gocov/gocov; go get github.com/matm/gocov-html; go get -u github.com/jstemmer/go-junit-report
     - go get -u github.com/kardianos/govendor
-    - govendor sync:
-        pwd:
-          ../.go_project/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+  override:
+    - cd $GO_PROJECT_PATH && govendor sync
+    - cd $GO_PROJECT_PATH && go get -t -d -v ./...
+    - cd $GO_PROJECT_PATH && go build -v
 
 test:
   pre:
+    - go get -u github.com/jstemmer/go-junit-report
     - go get -u github.com/mattn/goveralls
   override:
     - mkdir -p $CIRCLE_TEST_REPORTS/golang
-    - go test -race -v +local ./... | go-junit-report > $CIRCLE_TEST_REPORTS/golang/junit.xml
-    - go list ./... | grep -v vendor | awk -F/ '{print $4}' | xargs -I {} go test -v +local -cover -race -coverprofile=$CIRCLE_ARTIFACTS/{}.out ./{}
+    - cd $GO_PROJECT_PATH && govendor test -race -v +local | go-junit-report > $CIRCLE_TEST_REPORTS/golang/junit.xml
+    - cd $GO_PROJECT_PATH && govendor test -v -cover -race -coverprofile=$CIRCLE_ARTIFACTS/coverage.out +local
     - cd $CIRCLE_ARTIFACTS && sed -i '1d' *.out
     - |
       echo "mode: atomic" > $CIRCLE_ARTIFACTS/overall-coverage.result
     - cd $CIRCLE_ARTIFACTS && cat *.out >> overall-coverage.result
   post:
     - goveralls -coverprofile=$CIRCLE_ARTIFACTS/overall-coverage.result -service=circle-ci -repotoken=$COVERALLS_TOKEN
-    - bash <(curl -s https://codecov.io/bash)
     

--- a/circle.yml
+++ b/circle.yml
@@ -14,8 +14,8 @@ dependencies:
   pre:
     - go get -u github.com/kardianos/govendor
   override:
-    - cd $GO_PROJECT_PATH && govendor sync
-    - cd $GO_PROJECT_PATH && go build -v
+    - cd $PROJECT_PATH && govendor sync
+    - cd $PROJECT_PATH && go build -v
 
 test:
   pre:
@@ -23,8 +23,8 @@ test:
     - go get -u github.com/mattn/goveralls
   override:
     - mkdir -p $CIRCLE_TEST_REPORTS/golang
-    - cd $GO_PROJECT_PATH && govendor test -race -v +local ./... | go-junit-report > $CIRCLE_TEST_REPORTS/golang/junit.xml
-    - cd $GO_PROJECT_PATH && go list ./... | grep -v vendor | awk -F/ '{print $4}' | xargs -I {} govendor test -v -cover -race +local -coverprofile=$CIRCLE_ARTIFACTS/{}.out ./{}
+    - cd $PROJECT_PATH && govendor test -race -v +local ./... | go-junit-report > $CIRCLE_TEST_REPORTS/golang/junit.xml
+    - cd $PROJECT_PATH && go list ./... | grep -v vendor | awk -F/ '{print $4}' | xargs -I {} govendor test -v -cover -race +local -coverprofile=$CIRCLE_ARTIFACTS/{}.out ./{}
     - cd $CIRCLE_ARTIFACTS && sed -i '1d' *.out
     - |
       echo "mode: atomic" > $CIRCLE_ARTIFACTS/overall-coverage.result

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,7 @@ test:
   override:
     - mkdir -p $CIRCLE_TEST_REPORTS/golang
     - cd $PROJECT_PATH && govendor test -race -v +local ./... | go-junit-report > $CIRCLE_TEST_REPORTS/golang/junit.xml
-    - cd $PROJECT_PATH && go list ./... | grep -v vendor | awk -F/ '{print $4}' | xargs -I {} go test -v -cover -race +local -coverprofile=$CIRCLE_ARTIFACTS/{}.out ./{}
+    - cd $PROJECT_PATH && go list ./... | grep -v vendor | awk -F/ '{print $4}' | xargs -I {} go test -v -cover -race -coverprofile=$CIRCLE_ARTIFACTS/{}.out ./{}
     - cd $CIRCLE_ARTIFACTS && sed -i '1d' *.out
     - |
       echo "mode: atomic" > $CIRCLE_ARTIFACTS/overall-coverage.result

--- a/circle.yml
+++ b/circle.yml
@@ -7,8 +7,8 @@ machine:
 
 checkout:
   post:
+    - mkdir -p "${PROJECT_PARENT_PATH}"
     - rsync -avC "${HOME}/${CIRCLE_PROJECT_REPONAME}/" "${PROJECT_PATH}"
-    - mkdir -p $(dirname ${GO_PROJECT_PATH})
 
 dependencies:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -1,19 +1,20 @@
 machine:
   environment:
-    GOPATH: "${HOME}/.go_workspace:/usr/local/go_workspace:${HOME}/.go_project"
-    GO_PROJECT_PATH: "${HOME}/.go_project/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+    PROJECT_GOPATH: "${HOME}/.go_project"
+    PROJECT_PARENT_PATH: "${PROJECT_GOPATH}/src/github.com/${CIRCLE_PROJECT_USERNAME}"
+    PROJECT_PATH: "${PROJECT_PARENT_PATH}/${CIRCLE_PROJECT_REPONAME}"
+    GOPATH: "${HOME}/.go_workspace:${PROJECT_GOPATH}"
 
 checkout:
   post:
+    - rsync -avC "${HOME}/${CIRCLE_PROJECT_REPONAME}/" "${PROJECT_PATH}"
     - mkdir -p $(dirname ${GO_PROJECT_PATH})
-    - ln -fs $HOME/$CIRCLE_PROJECT_REPONAME $GO_PROJECT_PATH
 
 dependencies:
   pre:
     - go get -u github.com/kardianos/govendor
   override:
     - cd $GO_PROJECT_PATH && govendor sync
-    - cd $GO_PROJECT_PATH && go get -t -d -v ./...
     - cd $GO_PROJECT_PATH && go build -v
 
 test:
@@ -22,8 +23,8 @@ test:
     - go get -u github.com/mattn/goveralls
   override:
     - mkdir -p $CIRCLE_TEST_REPORTS/golang
-    - cd $GO_PROJECT_PATH && govendor test -race -v +local | go-junit-report > $CIRCLE_TEST_REPORTS/golang/junit.xml
-    - cd $GO_PROJECT_PATH && govendor test -v -cover -race -coverprofile=$CIRCLE_ARTIFACTS/coverage.out +local
+    - cd $GO_PROJECT_PATH && govendor test -race -v +local ./... | go-junit-report > $CIRCLE_TEST_REPORTS/golang/junit.xml
+    - cd $GO_PROJECT_PATH && go list ./... | grep -v vendor | awk -F/ '{print $4}' | xargs -I {} govendor test -v -cover -race +local -coverprofile=$CIRCLE_ARTIFACTS/{}.out ./{}
     - cd $CIRCLE_ARTIFACTS && sed -i '1d' *.out
     - |
       echo "mode: atomic" > $CIRCLE_ARTIFACTS/overall-coverage.result

--- a/circle.yml
+++ b/circle.yml
@@ -16,6 +16,13 @@ dependencies:
   override:
     - cd $PROJECT_PATH && govendor sync
     - cd $PROJECT_PATH && go build -v
+  post:
+    # We are using 5.1.x at the moment
+    - wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.1.2.tar.gz
+    - tar -xvf elasticsearch-5.1.2.tar.gz
+    - elasticsearch-5.1.2/bin/elasticsearch: {background: true}
+    # Make sure that Elasticsearch is up before running tests:
+    - sleep 10 && wget --waitretry=5 --retry-connrefused -v http://127.0.0.1:9200/
 
 test:
   pre:
@@ -23,8 +30,12 @@ test:
     - go get -u github.com/mattn/goveralls
   override:
     - mkdir -p $CIRCLE_TEST_REPORTS/golang
-    - cd $PROJECT_PATH && govendor test -race -v +local ./... | go-junit-report > $CIRCLE_TEST_REPORTS/golang/junit.xml
-    - cd $PROJECT_PATH && go list ./... | grep -v vendor | awk -F/ '{print $4}' | xargs -I {} go test -v -cover -race -coverprofile=$CIRCLE_ARTIFACTS/{}.out ./{}
+    - |
+      export ELASTICSEARCH_TEST_URL=http://127.0.0.1:9200
+      cd $PROJECT_PATH && govendor test -race -v +local ./... | go-junit-report > $CIRCLE_TEST_REPORTS/golang/junit.xml
+    - |
+      export ELASTICSEARCH_TEST_URL=http://127.0.0.1:9200
+      cd $PROJECT_PATH && go list ./... | grep -v vendor | awk -F/ '{print $4}' | xargs -I {} go test -v -cover -race -coverprofile=$CIRCLE_ARTIFACTS/{}.out ./{}
     - cd $CIRCLE_ARTIFACTS && sed -i '1d' *.out
     - |
       echo "mode: atomic" > $CIRCLE_ARTIFACTS/overall-coverage.result

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,7 @@ test:
   override:
     - mkdir -p $CIRCLE_TEST_REPORTS/golang
     - cd $PROJECT_PATH && govendor test -race -v +local ./... | go-junit-report > $CIRCLE_TEST_REPORTS/golang/junit.xml
-    - cd $PROJECT_PATH && go list ./... | grep -v vendor | awk -F/ '{print $4}' | xargs -I {} govendor test -v -cover -race +local -coverprofile=$CIRCLE_ARTIFACTS/{}.out ./{}
+    - cd $PROJECT_PATH && go list ./... | grep -v vendor | awk -F/ '{print $4}' | xargs -I {} go test -v -cover -race +local -coverprofile=$CIRCLE_ARTIFACTS/{}.out ./{}
     - cd $CIRCLE_ARTIFACTS && sed -i '1d' *.out
     - |
       echo "mode: atomic" > $CIRCLE_ARTIFACTS/overall-coverage.result

--- a/circle.yml
+++ b/circle.yml
@@ -1,33 +1,27 @@
-machine:
-  environment:
-    GOPATH: "${HOME}/.go_workspace:/usr/local/go_workspace:${HOME}/.go_project"
-    GO_PROJECT_PATH: "${HOME}/.go_project/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
-
-checkout:
-  post:
-    - mkdir -p $(dirname ${GO_PROJECT_PATH})
-    - ln -fs $HOME/$CIRCLE_PROJECT_REPONAME $GO_PROJECT_PATH
-
 dependencies:
   pre:
+    - mkdir -p $HOME/.go_project/src/github.com/$CIRCLE_PROJECT_USERNAME
+    - ln -fs $HOME/$CIRCLE_PROJECT_REPONAME $HOME/.go_project/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+    - |
+      echo 'export GOPATH=$GOPATH:$HOME/.go_project' >> ~/.circlerc
+    - go get github.com/axw/gocov/gocov; go get github.com/matm/gocov-html; go get -u github.com/jstemmer/go-junit-report
     - go get -u github.com/kardianos/govendor
-  override:
-    - cd $GO_PROJECT_PATH && govendor sync
-    - cd $GO_PROJECT_PATH && go get -t -d -v ./...
-    - cd $GO_PROJECT_PATH && go build -v
+    - govendor sync:
+        pwd:
+          ../.go_project/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
 
 test:
   pre:
-    - go get -u github.com/jstemmer/go-junit-report
     - go get -u github.com/mattn/goveralls
   override:
     - mkdir -p $CIRCLE_TEST_REPORTS/golang
-    - cd $GO_PROJECT_PATH && govendor test -race -v +local | go-junit-report > $CIRCLE_TEST_REPORTS/golang/junit.xml
-    - cd $GO_PROJECT_PATH && govendor test -v -cover -race -coverprofile=$CIRCLE_ARTIFACTS/coverage.out +local
+    - go test -race -v +local ./... | go-junit-report > $CIRCLE_TEST_REPORTS/golang/junit.xml
+    - go list ./... | grep -v vendor | awk -F/ '{print $4}' | xargs -I {} go test -v +local -cover -race -coverprofile=$CIRCLE_ARTIFACTS/{}.out ./{}
     - cd $CIRCLE_ARTIFACTS && sed -i '1d' *.out
     - |
       echo "mode: atomic" > $CIRCLE_ARTIFACTS/overall-coverage.result
     - cd $CIRCLE_ARTIFACTS && cat *.out >> overall-coverage.result
   post:
     - goveralls -coverprofile=$CIRCLE_ARTIFACTS/overall-coverage.result -service=circle-ci -repotoken=$COVERALLS_TOKEN
+    - bash <(curl -s https://codecov.io/bash)
     

--- a/client.go
+++ b/client.go
@@ -1,12 +1,13 @@
 package main
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"time"
 
 	awsauth "github.com/smartystreets/go-aws-auth"
-	"gopkg.in/olivere/elastic.v3"
+	"gopkg.in/olivere/elastic.v5"
 )
 
 type esClient interface {
@@ -58,9 +59,9 @@ func newElasticClient(accessKey string, secretKey string, endpoint *string, regi
 }
 
 func (ec esClientWrapper) query(indexName string, query elastic.Query, resultLimit int) (*elastic.SearchResult, error) {
-	return ec.elasticClient.Search().Index(indexName).Query(query).Size(resultLimit).Do()
+	return ec.elasticClient.Search().Index(indexName).Query(query).Size(resultLimit).Do(context.Background())
 }
 
 func (ec esClientWrapper) getClusterHealth() (*elastic.ClusterHealthResponse, error) {
-	return ec.elasticClient.ClusterHealth().Do()
+	return ec.elasticClient.ClusterHealth().Do(context.Background())
 }

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Financial-Times/go-fthealth/v1a"
 	log "github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
-	"gopkg.in/olivere/elastic.v3"
+	"gopkg.in/olivere/elastic.v5"
 )
 
 type esHealthService struct {

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -11,7 +11,7 @@ import (
 
 	"strings"
 
-	"gopkg.in/olivere/elastic.v3"
+	"gopkg.in/olivere/elastic.v5"
 )
 
 func TestHealthDetailsHealthyCluster(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func routeRequest(port *string, conceptFinder conceptFinder, handler *resources.
 
 	http.Handle("/", monitoringRouter)
 
-	log.Info("Concept Search API starting up...")
+	log.Infof("Concept Search API listening on port %v...", *port)
 	if err := http.ListenAndServe(":"+*port, nil); err != nil {
 		log.Fatalf("Unable to start: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 
 	app.Action = func() {
 		logStartupConfig(port, esEndpoint, esRegion, esIndex, searchResultLimit)
-		esClient, err := service.NewElasticClient(*esRegion, accessConfig /*accessConfig.accessKey, accessConfig.secretKey, &accessConfig.esEndpoint, &accessConfig.esRegion*/)
+		esClient, err := service.NewElasticClient(*esRegion, accessConfig)
 		if err != nil {
 			log.Fatalf("Creating elasticsearch client failed with error=[%v]", err)
 		}

--- a/resources/handler.go
+++ b/resources/handler.go
@@ -1,0 +1,46 @@
+package resources
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/Financial-Times/concept-search-api/service"
+	log "github.com/Sirupsen/logrus"
+)
+
+type Handler struct {
+	service service.ConceptSearchService
+}
+
+func NewHandler(service service.ConceptSearchService) *Handler {
+	return &Handler{service}
+}
+
+func (h *Handler) ConceptSearch(w http.ResponseWriter, req *http.Request) {
+	query := req.URL.Query()
+	log.Infof("query: %v", query)
+
+	values := query["q"]
+	conceptTypes := query["type"]
+	var concepts []service.Concept
+	var err error
+
+	if len(conceptTypes) > 0 && conceptTypes[0] != "" && len(values) == 0 {
+		concepts, err = h.service.FindAllConceptsByType(conceptTypes[0])
+	} else {
+		err = service.ErrInvalidConceptType
+	}
+
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+
+		by, e2 := json.Marshal(map[string]string{"error": err.Error()})
+		if e2 != nil {
+			w.Write(by)
+		}
+
+		return
+	}
+
+	json.NewEncoder(w).Encode(concepts)
+}

--- a/resources/handler.go
+++ b/resources/handler.go
@@ -23,7 +23,7 @@ func (h *Handler) ConceptSearch(w http.ResponseWriter, req *http.Request) {
 	response := make(map[string]interface{})
 	var err error
 
-	if len(conceptTypes) > 0 && conceptTypes[0] != "" && len(values) == 0 {
+	if len(conceptTypes) == 1 && conceptTypes[0] != "" && len(values) == 0 {
 		var concepts []service.Concept
 		concepts, err = h.service.FindAllConceptsByType(conceptTypes[0])
 		if err == nil {

--- a/resources/handler_test.go
+++ b/resources/handler_test.go
@@ -1,0 +1,121 @@
+package resources
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/Financial-Times/concept-search-api/service"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+type dummyConceptSearchService struct {
+	concepts []service.Concept
+	err      error
+}
+
+func (s *dummyConceptSearchService) FindAllConceptsByType(conceptType string) ([]service.Concept, error) {
+	return s.concepts, s.err
+}
+
+func TestConceptSearchByType(t *testing.T) {
+	req, err := http.NewRequest("GET", "/concepts?type=http%3A%2F%2Fwww.ft.com%2Fontology%2FGenre", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	genres := []service.Concept{
+		service.Concept{
+			Id:          "http://api.ft.com/things/1",
+			ApiUrl:      "http://api.ft.com/things/1",
+			PrefLabel:   "Test Genre 1",
+			ConceptType: "http://www.ft.com/ontology/Genre",
+		},
+		service.Concept{
+			Id:          "http://api.ft.com/things/2",
+			ApiUrl:      "http://api.ft.com/things/2",
+			PrefLabel:   "Test Genre 2",
+			ConceptType: "http://www.ft.com/ontology/Genre",
+		},
+	}
+
+	dummyService := &dummyConceptSearchService{concepts: genres}
+	endpoint := NewHandler(dummyService)
+
+	router := mux.NewRouter()
+	router.HandleFunc("/concepts", endpoint.ConceptSearch).Methods("GET")
+
+	actual := httptest.NewRecorder()
+	router.ServeHTTP(actual, req)
+
+	assert.Equal(t, http.StatusOK, actual.Code, "http status")
+	assert.Equal(t, "application/json", actual.Header().Get("Content-Type"), "content-type")
+
+	respObject := make(map[string][]service.Concept)
+	err = json.Unmarshal(actual.Body.Bytes(), &respObject)
+	if err != nil {
+		t.Errorf("Unmarshalling request response failed. %v", err)
+	}
+
+	assert.Len(t, respObject["concepts"], 2, "concepts")
+	assert.True(t, reflect.DeepEqual(respObject["concepts"], genres))
+}
+
+func TestConceptSearchByTypeClientError(t *testing.T) {
+	req, err := http.NewRequest("GET", "/concepts?type=http%3A%2F%2Fwww.ft.com%2Fontology%2FFoo", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dummyService := &dummyConceptSearchService{err: service.ErrInvalidConceptType}
+	endpoint := NewHandler(dummyService)
+
+	router := mux.NewRouter()
+	router.HandleFunc("/concepts", endpoint.ConceptSearch).Methods("GET")
+
+	actual := httptest.NewRecorder()
+	router.ServeHTTP(actual, req)
+
+	assert.Equal(t, http.StatusBadRequest, actual.Code, "http status")
+	assert.Equal(t, "application/json", actual.Header().Get("Content-Type"), "content-type")
+
+	respObject := make(map[string]string)
+	err = json.Unmarshal(actual.Body.Bytes(), &respObject)
+	if err != nil {
+		t.Errorf("Unmarshalling request response failed. %v", err)
+	}
+
+	assert.Equal(t, service.ErrInvalidConceptType.Error(), respObject["message"], "error message")
+}
+
+func TestConceptSearchByTypeServerError(t *testing.T) {
+	req, err := http.NewRequest("GET", "/concepts?type=http%3A%2F%2Fwww.ft.com%2Fontology%2FGenre", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedError := errors.New("Test error")
+	dummyService := &dummyConceptSearchService{err: expectedError}
+	endpoint := NewHandler(dummyService)
+
+	router := mux.NewRouter()
+	router.HandleFunc("/concepts", endpoint.ConceptSearch).Methods("GET")
+
+	actual := httptest.NewRecorder()
+	router.ServeHTTP(actual, req)
+
+	assert.Equal(t, http.StatusInternalServerError, actual.Code, "http status")
+	assert.Equal(t, "application/json", actual.Header().Get("Content-Type"), "content-type")
+
+	respObject := make(map[string]string)
+	err = json.Unmarshal(actual.Body.Bytes(), &respObject)
+	if err != nil {
+		t.Errorf("Unmarshalling request response failed. %v", err)
+	}
+
+	assert.Equal(t, expectedError.Error(), respObject["message"], "error message")
+}

--- a/resources/handler_test.go
+++ b/resources/handler_test.go
@@ -11,24 +11,20 @@ import (
 	"github.com/Financial-Times/concept-search-api/service"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
-type dummyConceptSearchService struct {
-	concepts []service.Concept
-	err      error
+type mockConceptSearchService struct {
+	mock.Mock
 }
 
-func (s *dummyConceptSearchService) FindAllConceptsByType(conceptType string) ([]service.Concept, error) {
-	return s.concepts, s.err
+func (s *mockConceptSearchService) FindAllConceptsByType(conceptType string) ([]service.Concept, error) {
+	args := s.Called(conceptType)
+	return args.Get(0).([]service.Concept), args.Error(1)
 }
 
-func TestConceptSearchByType(t *testing.T) {
-	req, err := http.NewRequest("GET", "/concepts?type=http%3A%2F%2Fwww.ft.com%2Fontology%2FGenre", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	genres := []service.Concept{
+func dummyGenres() []service.Concept {
+	return []service.Concept{
 		service.Concept{
 			Id:          "http://api.ft.com/things/1",
 			ApiUrl:      "http://api.ft.com/things/1",
@@ -42,9 +38,15 @@ func TestConceptSearchByType(t *testing.T) {
 			ConceptType: "http://www.ft.com/ontology/Genre",
 		},
 	}
+}
 
-	dummyService := &dummyConceptSearchService{concepts: genres}
-	endpoint := NewHandler(dummyService)
+func TestConceptSearchByType(t *testing.T) {
+	req := httptest.NewRequest("GET", "/concepts?type=http%3A%2F%2Fwww.ft.com%2Fontology%2FGenre", nil)
+
+	genres := dummyGenres()
+	svc := mockConceptSearchService{}
+	svc.On("FindAllConceptsByType", "http://www.ft.com/ontology/Genre").Return(genres, nil)
+	endpoint := NewHandler(&svc)
 
 	router := mux.NewRouter()
 	router.HandleFunc("/concepts", endpoint.ConceptSearch).Methods("GET")
@@ -56,7 +58,7 @@ func TestConceptSearchByType(t *testing.T) {
 	assert.Equal(t, "application/json", actual.Header().Get("Content-Type"), "content-type")
 
 	respObject := make(map[string][]service.Concept)
-	err = json.Unmarshal(actual.Body.Bytes(), &respObject)
+	err := json.Unmarshal(actual.Body.Bytes(), &respObject)
 	if err != nil {
 		t.Errorf("Unmarshalling request response failed. %v", err)
 	}
@@ -66,13 +68,11 @@ func TestConceptSearchByType(t *testing.T) {
 }
 
 func TestConceptSearchByTypeClientError(t *testing.T) {
-	req, err := http.NewRequest("GET", "/concepts?type=http%3A%2F%2Fwww.ft.com%2Fontology%2FFoo", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := httptest.NewRequest("GET", "/concepts?type=http%3A%2F%2Fwww.ft.com%2Fontology%2FFoo", nil)
 
-	dummyService := &dummyConceptSearchService{err: service.ErrInvalidConceptType}
-	endpoint := NewHandler(dummyService)
+	svc := mockConceptSearchService{}
+	svc.On("FindAllConceptsByType", mock.AnythingOfType("string")).Return([]service.Concept{}, service.ErrInvalidConceptType)
+	endpoint := NewHandler(&svc)
 
 	router := mux.NewRouter()
 	router.HandleFunc("/concepts", endpoint.ConceptSearch).Methods("GET")
@@ -84,7 +84,7 @@ func TestConceptSearchByTypeClientError(t *testing.T) {
 	assert.Equal(t, "application/json", actual.Header().Get("Content-Type"), "content-type")
 
 	respObject := make(map[string]string)
-	err = json.Unmarshal(actual.Body.Bytes(), &respObject)
+	err := json.Unmarshal(actual.Body.Bytes(), &respObject)
 	if err != nil {
 		t.Errorf("Unmarshalling request response failed. %v", err)
 	}
@@ -93,14 +93,12 @@ func TestConceptSearchByTypeClientError(t *testing.T) {
 }
 
 func TestConceptSearchByTypeServerError(t *testing.T) {
-	req, err := http.NewRequest("GET", "/concepts?type=http%3A%2F%2Fwww.ft.com%2Fontology%2FGenre", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := httptest.NewRequest("GET", "/concepts?type=http%3A%2F%2Fwww.ft.com%2Fontology%2FGenre", nil)
 
 	expectedError := errors.New("Test error")
-	dummyService := &dummyConceptSearchService{err: expectedError}
-	endpoint := NewHandler(dummyService)
+	svc := mockConceptSearchService{}
+	svc.On("FindAllConceptsByType", mock.AnythingOfType("string")).Return([]service.Concept{}, expectedError)
+	endpoint := NewHandler(&svc)
 
 	router := mux.NewRouter()
 	router.HandleFunc("/concepts", endpoint.ConceptSearch).Methods("GET")
@@ -112,10 +110,111 @@ func TestConceptSearchByTypeServerError(t *testing.T) {
 	assert.Equal(t, "application/json", actual.Header().Get("Content-Type"), "content-type")
 
 	respObject := make(map[string]string)
-	err = json.Unmarshal(actual.Body.Bytes(), &respObject)
+	err := json.Unmarshal(actual.Body.Bytes(), &respObject)
 	if err != nil {
 		t.Errorf("Unmarshalling request response failed. %v", err)
 	}
 
 	assert.Equal(t, expectedError.Error(), respObject["message"], "error message")
+}
+
+func TestConceptSeachByTypeNoType(t *testing.T) {
+	req := httptest.NewRequest("GET", "/concepts", nil)
+
+	svc := mockConceptSearchService{}
+	endpoint := NewHandler(&svc)
+
+	router := mux.NewRouter()
+	router.HandleFunc("/concepts", endpoint.ConceptSearch).Methods("GET")
+
+	actual := httptest.NewRecorder()
+	router.ServeHTTP(actual, req)
+
+	assert.Equal(t, http.StatusBadRequest, actual.Code, "http status")
+	assert.Equal(t, "application/json", actual.Header().Get("Content-Type"), "content-type")
+
+	respObject := make(map[string]string)
+	err := json.Unmarshal(actual.Body.Bytes(), &respObject)
+	if err != nil {
+		t.Errorf("Unmarshalling request response failed. %v", err)
+	}
+
+	assert.Equal(t, service.ErrInvalidConceptType.Error(), respObject["message"], "error message")
+	svc.AssertExpectations(t)
+}
+
+func TestConceptSeachByTypeBlankType(t *testing.T) {
+	req := httptest.NewRequest("GET", "/concepts?type=", nil)
+
+	svc := mockConceptSearchService{}
+	endpoint := NewHandler(&svc)
+
+	router := mux.NewRouter()
+	router.HandleFunc("/concepts", endpoint.ConceptSearch).Methods("GET")
+
+	actual := httptest.NewRecorder()
+	router.ServeHTTP(actual, req)
+
+	assert.Equal(t, http.StatusBadRequest, actual.Code, "http status")
+	assert.Equal(t, "application/json", actual.Header().Get("Content-Type"), "content-type")
+
+	respObject := make(map[string]string)
+	err := json.Unmarshal(actual.Body.Bytes(), &respObject)
+	if err != nil {
+		t.Errorf("Unmarshalling request response failed. %v", err)
+	}
+
+	assert.Equal(t, service.ErrInvalidConceptType.Error(), respObject["message"], "error message")
+
+	svc.AssertExpectations(t)
+}
+
+func TestConceptSeachByTypeMultipleTypes(t *testing.T) {
+	req := httptest.NewRequest("GET", "/concepts?type=http%3A%2F%2Fwww.ft.com%2Fontology%2Fperson%2FPerson&type=http%3A%2F%2Fwww.ft.com%2Fontology%2FGenre", nil)
+
+	svc := mockConceptSearchService{}
+	endpoint := NewHandler(&svc)
+
+	router := mux.NewRouter()
+	router.HandleFunc("/concepts", endpoint.ConceptSearch).Methods("GET")
+
+	actual := httptest.NewRecorder()
+	router.ServeHTTP(actual, req)
+
+	assert.Equal(t, http.StatusBadRequest, actual.Code, "http status")
+	assert.Equal(t, "application/json", actual.Header().Get("Content-Type"), "content-type")
+
+	respObject := make(map[string]string)
+	err := json.Unmarshal(actual.Body.Bytes(), &respObject)
+	if err != nil {
+		t.Errorf("Unmarshalling request response failed. %v", err)
+	}
+
+	assert.Equal(t, service.ErrInvalidConceptType.Error(), respObject["message"], "error message")
+	svc.AssertExpectations(t)
+}
+
+func TestConceptSeachByTypeAndValue(t *testing.T) {
+	req := httptest.NewRequest("GET", "/concepts?type=http%3A%2F%2Fwww.ft.com%2Fontology%2FGenre&q=fast", nil)
+
+	svc := mockConceptSearchService{}
+	endpoint := NewHandler(&svc)
+
+	router := mux.NewRouter()
+	router.HandleFunc("/concepts", endpoint.ConceptSearch).Methods("GET")
+
+	actual := httptest.NewRecorder()
+	router.ServeHTTP(actual, req)
+
+	assert.Equal(t, http.StatusBadRequest, actual.Code, "http status")
+	assert.Equal(t, "application/json", actual.Header().Get("Content-Type"), "content-type")
+
+	respObject := make(map[string]string)
+	err := json.Unmarshal(actual.Body.Bytes(), &respObject)
+	if err != nil {
+		t.Errorf("Unmarshalling request response failed. %v", err)
+	}
+
+	assert.Equal(t, service.ErrInvalidConceptType.Error(), respObject["message"], "error message")
+	svc.AssertExpectations(t)
 }

--- a/service.go
+++ b/service.go
@@ -21,13 +21,6 @@ type esConceptFinder struct {
 	searchResultLimit int
 }
 
-type esAccessConfig struct {
-	accessKey  string
-	secretKey  string
-	esEndpoint string
-	esRegion   string
-}
-
 func (service esConceptFinder) FindConcept(writer http.ResponseWriter, request *http.Request) {
 	if service.client == nil {
 		log.Errorf("Elasticsearch client is not created.")

--- a/service.go
+++ b/service.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/Financial-Times/transactionid-utils-go"
 	log "github.com/Sirupsen/logrus"
-	"gopkg.in/olivere/elastic.v3"
+	"gopkg.in/olivere/elastic.v5"
 )
 
 type conceptFinder interface {

--- a/service/es_client.go
+++ b/service/es_client.go
@@ -1,0 +1,65 @@
+package service
+
+import (
+	"net/http"
+
+	log "github.com/Sirupsen/logrus"
+	awsauth "github.com/smartystreets/go-aws-auth"
+	"gopkg.in/olivere/elastic.v3"
+)
+
+type EsAccessConfig struct {
+	accessKey  string
+	secretKey  string
+	esEndpoint string
+}
+
+func NewAccessConfig(accessKey string, secretKey string, endpoint string) EsAccessConfig {
+	return EsAccessConfig{accessKey: accessKey, secretKey: secretKey, esEndpoint: endpoint}
+}
+
+type AWSSigningTransport struct {
+	HTTPClient  *http.Client
+	Credentials awsauth.Credentials
+}
+
+// RoundTrip implementation
+func (a AWSSigningTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return a.HTTPClient.Do(awsauth.Sign4(req, a.Credentials))
+}
+
+func newAmazonClient(config EsAccessConfig) (*elastic.Client, error) {
+
+	signingTransport := AWSSigningTransport{
+		Credentials: awsauth.Credentials{
+			AccessKeyID:     config.accessKey,
+			SecretAccessKey: config.secretKey,
+		},
+		HTTPClient: http.DefaultClient,
+	}
+	signingClient := &http.Client{Transport: http.RoundTripper(signingTransport)}
+
+	log.Infof("connecting with AWSSigningTransport to %s", config.esEndpoint)
+	return elastic.NewClient(
+		elastic.SetURL(config.esEndpoint),
+		elastic.SetScheme("https"),
+		elastic.SetHttpClient(signingClient),
+		elastic.SetSniff(false), //needs to be disabled due to EAS behavior. Healthcheck still operates as normal.
+	)
+}
+
+func newSimpleClient(config EsAccessConfig) (*elastic.Client, error) {
+	log.Infof("connecting with default transport to %s", config.esEndpoint)
+	return elastic.NewClient(
+		elastic.SetURL(config.esEndpoint),
+		elastic.SetSniff(false),
+	)
+}
+
+func NewElasticClient(region string, config EsAccessConfig) (*elastic.Client, error) {
+	if region == "local" {
+		return newSimpleClient(config)
+	} else {
+		return newAmazonClient(config)
+	}
+}

--- a/service/es_client.go
+++ b/service/es_client.go
@@ -5,7 +5,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	awsauth "github.com/smartystreets/go-aws-auth"
-	"gopkg.in/olivere/elastic.v3"
+	"gopkg.in/olivere/elastic.v5"
 )
 
 type EsAccessConfig struct {

--- a/service/model.go
+++ b/service/model.go
@@ -1,0 +1,61 @@
+package service
+
+type EsConceptModel struct {
+	Id         string   `json:"id"`
+	ApiUrl     string   `json:"apiUrl"`
+	PrefLabel  string   `json:"prefLabel"`
+	Types      []string `json:"types"`
+	DirectType string   `json:"directType"`
+	Aliases    []string `json:"aliases,omitempty"`
+}
+
+type Concept struct {
+	Id          string `json:"id"`
+	ApiUrl      string `json:"apiUrl"`
+	PrefLabel   string `json:"prefLabel"`
+	ConceptType string `json:"type"`
+}
+
+type Concepts []Concept
+
+var (
+	esTypeMapping = map[string]string{
+		"http://www.ft.com/ontology/Genre": "genres",
+	}
+)
+
+func ConvertToSimpleConcept(esConcept EsConceptModel, esType string) Concept {
+	c := Concept{}
+	c.Id = esConcept.Id
+	c.ApiUrl = esConcept.ApiUrl
+	c.ConceptType = ftType(esType)
+	c.PrefLabel = esConcept.PrefLabel
+
+	return c
+}
+
+func esType(ftType string) string {
+	return esTypeMapping[ftType]
+}
+
+func ftType(esType string) string {
+	for k, v := range esTypeMapping {
+		if v == esType {
+			return k
+		}
+	}
+
+	return ""
+}
+
+func (slice Concepts) Len() int {
+	return len(slice)
+}
+
+func (slice Concepts) Less(i, j int) bool {
+	return slice[i].PrefLabel < slice[j].PrefLabel
+}
+
+func (slice Concepts) Swap(i, j int) {
+	slice[i], slice[j] = slice[j], slice[i]
+}

--- a/service/model_test.go
+++ b/service/model_test.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConceptsSortInterface(t *testing.T) {
+	concept1 := Concept{
+		Id:          "id1",
+		ApiUrl:      "http://www.example.com/thing/1",
+		PrefLabel:   "Concept 1",
+		ConceptType: "http://www.ft.com/ontology/Genre",
+	}
+
+	concept2 := Concept{
+		Id:          "id2",
+		ApiUrl:      "http://www.example.com/thing/2",
+		PrefLabel:   "Concept 2",
+		ConceptType: "http://www.ft.com/ontology/Genre",
+	}
+
+	concepts := Concepts{concept1, concept2}
+
+	assert.Equal(t, 2, concepts.Len(), "slice length")
+	assert.True(t, concepts.Less(0, 1), "concept ordering by prefLabel")
+	assert.False(t, concepts.Less(1, 0), "concept ordering by prefLabel")
+
+	concepts.Swap(0, 1)
+
+	assert.Equal(t, concept2, concepts[0], "swapped concepts")
+	assert.Equal(t, concept1, concepts[1], "swapped concepts")
+
+	assert.Equal(t, 2, concepts.Len(), "slice length")
+	assert.True(t, concepts.Less(1, 0), "concept ordering by prefLabel")
+	assert.False(t, concepts.Less(0, 1), "concept ordering by prefLabel")
+}
+
+func TestEsType(t *testing.T) {
+	assert.Equal(t, "genres", esType("http://www.ft.com/ontology/Genre"), "known type conversion")
+	assert.Equal(t, "", esType("http://www.ft.com/ontology/Foo"), "unknown type conversion")
+}
+
+func TestFtType(t *testing.T) {
+	assert.Equal(t, "http://www.ft.com/ontology/Genre", ftType("genres"), "known type conversion")
+	assert.Equal(t, "", ftType("tardigrades"), "unknown type conversion")
+}
+
+func TestConvertToSimpleConcept(t *testing.T) {
+	id := "id"
+	apiUrl := "http://www.example.com/1"
+	label := "Test Concept"
+
+	esConcept := EsConceptModel{
+		Id:         id,
+		ApiUrl:     apiUrl,
+		PrefLabel:  label,
+		Types:      []string{"any"},
+		DirectType: "any",
+		Aliases:    []string{},
+	}
+
+	actual := ConvertToSimpleConcept(esConcept, "genres")
+
+	assert.Equal(t, id, actual.Id, "id")
+	assert.Equal(t, apiUrl, actual.ApiUrl, "apiUrl")
+	assert.Equal(t, "http://www.ft.com/ontology/Genre", actual.ConceptType, "type")
+	assert.Equal(t, label, actual.PrefLabel, "prefLabel")
+}

--- a/service/search.go
+++ b/service/search.go
@@ -2,12 +2,13 @@ package service
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"sort"
 
 	log "github.com/Sirupsen/logrus"
-	"gopkg.in/olivere/elastic.v3"
+	"gopkg.in/olivere/elastic.v5"
 )
 
 var (
@@ -47,7 +48,7 @@ func (s *esConceptSearchService) FindAllConceptsByType(conceptType string) ([]Co
 	}
 
 	concepts := Concepts{}
-	result, err := s.esClient.Search(s.index).Type(t).Size(50).Do()
+	result, err := s.esClient.Search(s.index).Type(t).Size(50).Do(context.Background())
 	if err != nil {
 		log.Errorf("error: %v", err)
 	} else {

--- a/service/search.go
+++ b/service/search.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"sort"
+
+	log "github.com/Sirupsen/logrus"
+	"gopkg.in/olivere/elastic.v3"
+)
+
+var (
+	ErrNoElasticClient    error = errors.New("No ElasticSearch client available")
+	ErrInvalidConceptType       = errors.New("Invalid concept type")
+)
+
+type ConceptSearchService interface {
+	FindAllConceptsByType(conceptType string) ([]Concept, error)
+}
+
+type esConceptSearchService struct {
+	esClient *elastic.Client
+	index    string
+}
+
+func NewEsConceptSearchService(client *elastic.Client, index string) *esConceptSearchService {
+	return &esConceptSearchService{client, index}
+}
+
+func (s *esConceptSearchService) checkElasticClient() error {
+	if s.esClient == nil {
+		return ErrNoElasticClient
+	}
+
+	return nil
+}
+
+func (s *esConceptSearchService) FindAllConceptsByType(conceptType string) ([]Concept, error) {
+	t := esType(conceptType)
+	if t == "" {
+		return nil, ErrInvalidConceptType
+	}
+
+	if err := s.checkElasticClient(); err != nil {
+		return nil, err
+	}
+
+	concepts := Concepts{}
+	result, err := s.esClient.Search(s.index).Type(t).Size(50).Do()
+	if err != nil {
+		log.Errorf("error: %v", err)
+	} else {
+		for _, c := range result.Hits.Hits {
+			by, err := (*c.Source).MarshalJSON()
+			if err != nil {
+				log.Warnf("unmarshallable response from ElasticSearch: %v", err)
+				continue
+			}
+
+			esConcept := EsConceptModel{}
+			json.NewDecoder(bytes.NewReader(by)).Decode(&esConcept)
+
+			concept := ConvertToSimpleConcept(esConcept, c.Type)
+			concepts = append(concepts, concept)
+		}
+	}
+	sort.Sort(concepts)
+
+	return concepts, nil
+}

--- a/service/search.go
+++ b/service/search.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -53,14 +52,12 @@ func (s *esConceptSearchService) FindAllConceptsByType(conceptType string) ([]Co
 		log.Errorf("error: %v", err)
 	} else {
 		for _, c := range result.Hits.Hits {
-			by, err := (*c.Source).MarshalJSON()
+			esConcept := EsConceptModel{}
+			err := json.Unmarshal(*c.Source, &esConcept)
 			if err != nil {
 				log.Warnf("unmarshallable response from ElasticSearch: %v", err)
 				continue
 			}
-
-			esConcept := EsConceptModel{}
-			json.NewDecoder(bytes.NewReader(by)).Decode(&esConcept)
 
 			concept := ConvertToSimpleConcept(esConcept, c.Type)
 			concepts = append(concepts, concept)
@@ -68,5 +65,5 @@ func (s *esConceptSearchService) FindAllConceptsByType(conceptType string) ([]Co
 	}
 	sort.Sort(concepts)
 
-	return concepts, nil
+	return concepts, err
 }

--- a/service/search_test.go
+++ b/service/search_test.go
@@ -9,14 +9,15 @@ import (
 
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 	"gopkg.in/olivere/elastic.v5"
 )
 
 const (
-	apiBaseUrl  = "http://test.api.ft.com"
-	indexName   = "concept"
-	conceptType = "genres"
-	ftGenreType = "http://www.ft.com/ontology/Genre"
+	apiBaseUrl    = "http://test.api.ft.com"
+	testIndexName = "test-index"
+	conceptType   = "genres"
+	ftGenreType   = "http://www.ft.com/ontology/Genre"
 )
 
 func TestNoElasticClient(t *testing.T) {
@@ -25,6 +26,33 @@ func TestNoElasticClient(t *testing.T) {
 	_, err := service.FindAllConceptsByType(ftGenreType)
 
 	assert.Equal(t, ErrNoElasticClient, err, "error response")
+}
+
+type EsConceptSearchServiceTestSuite struct {
+	suite.Suite
+	esURL string
+	ec    *elastic.Client
+}
+
+func TestEsConceptSearchServiceSuite(t *testing.T) {
+	suite.Run(t, new(EsConceptSearchServiceTestSuite))
+}
+
+func (s *EsConceptSearchServiceTestSuite) SetupSuite() {
+	s.esURL = getElasticSearchTestURL(s.T())
+
+	ec, err := elastic.NewClient(
+		elastic.SetURL(s.esURL),
+		elastic.SetSniff(false),
+	)
+	assert.NoError(s.T(), err, "expected no error for ES client")
+
+	s.ec = ec
+	_ = writeTestConcepts(s.ec)
+}
+
+func (s *EsConceptSearchServiceTestSuite) TearDownSuite() {
+	s.ec.DeleteIndex(testIndexName).Do(context.Background())
 }
 
 func getElasticSearchTestURL(t *testing.T) string {
@@ -56,7 +84,7 @@ func writeTestConcepts(ec *elastic.Client) []string {
 		}
 
 		ec.Index().
-			Index(indexName).
+			Index(testIndexName).
 			Type(conceptType).
 			Id(u).
 			BodyJson(payload).
@@ -66,49 +94,31 @@ func writeTestConcepts(ec *elastic.Client) []string {
 	}
 
 	// ensure test data is immediately available from the index
-	ec.Refresh(indexName).Do(context.Background())
+	ec.Refresh(testIndexName).Do(context.Background())
 
 	return uuids
 }
 
-func TestFindAllConceptsByType(t *testing.T) {
-	esURL := getElasticSearchTestURL(t)
-
-	ec, err := elastic.NewClient(
-		elastic.SetURL(esURL),
-		elastic.SetSniff(false),
-	)
-	assert.NoError(t, err, "expected no error for ES client")
-
-	_ = writeTestConcepts(ec)
-
-	service := NewEsConceptSearchService(ec, indexName)
+func (s *EsConceptSearchServiceTestSuite) TestFindAllConceptsByType() {
+	service := NewEsConceptSearchService(s.ec, testIndexName)
 	concepts, err := service.FindAllConceptsByType(ftGenreType)
 
-	assert.NoError(t, err, "expected no error for ES read")
-	assert.True(t, len(concepts) > 1, "there should be at least two genres")
+	assert.NoError(s.T(), err, "expected no error for ES read")
+	assert.True(s.T(), len(concepts) > 1, "there should be at least two genres")
 
 	var prev string
 	for i := range concepts {
 		if i > 0 {
-			assert.Equal(t, -1, strings.Compare(prev, concepts[i].PrefLabel), "concepts should be ordered")
+			assert.Equal(s.T(), -1, strings.Compare(prev, concepts[i].PrefLabel), "concepts should be ordered")
 		}
 
 		prev = concepts[i].PrefLabel
 	}
 }
 
-func TestFindAllConceptsByTypeInvalid(t *testing.T) {
-	esURL := getElasticSearchTestURL(t)
+func (s *EsConceptSearchServiceTestSuite) TestFindAllConceptsByTypeInvalid() {
+	service := NewEsConceptSearchService(s.ec, testIndexName)
+	_, err := service.FindAllConceptsByType("http://www.ft.com/ontology/Foo")
 
-	ec, err := elastic.NewClient(
-		elastic.SetURL(esURL),
-		elastic.SetSniff(false),
-	)
-	assert.NoError(t, err, "expected no error for ES client")
-
-	service := NewEsConceptSearchService(ec, indexName)
-	_, err = service.FindAllConceptsByType("http://www.ft.com/ontology/Foo")
-
-	assert.Equal(t, ErrInvalidConceptType, err, "expected error for ES read")
+	assert.Equal(s.T(), ErrInvalidConceptType, err, "expected error for ES read")
 }

--- a/service/search_test.go
+++ b/service/search_test.go
@@ -1,0 +1,117 @@
+package service
+
+import (
+	"context"
+	//	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	//	"sync"
+	"testing"
+	//	"time"
+
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/olivere/elastic.v5"
+)
+
+const (
+	apiBaseUrl  = "http://test.api.ft.com"
+	indexName   = "concept"
+	conceptType = "genres"
+	ftGenreType = "http://www.ft.com/ontology/Genre"
+)
+
+func TestNoElasticClient(t *testing.T) {
+	service := esConceptSearchService{nil, "test"}
+
+	_, err := service.FindAllConceptsByType(ftGenreType)
+
+	assert.Equal(t, ErrNoElasticClient, err, "error response")
+}
+
+func getElasticSearchTestURL(t *testing.T) string {
+	if testing.Short() {
+		t.Skip("ElasticSearch integration for long tests only.")
+	}
+
+	esURL := os.Getenv("ELASTICSEARCH_TEST_URL")
+	if strings.TrimSpace(esURL) == "" {
+		t.Fatal("Please set the environment variable ELASTICSEARCH_TEST_URL to run ElasticSearch integration tests (e.g. export ELASTICSEARCH_TEST_URL=http://localhost:9200). Alternatively, run `go test -short` to skip them.")
+	}
+
+	return esURL
+}
+
+func writeTestConcepts(ec *elastic.Client) []string {
+	uuids := []string{}
+
+	for i := 0; i < 2; i++ {
+		u := uuid.NewV4().String()
+
+		payload := EsConceptModel{
+			Id:         u,
+			ApiUrl:     fmt.Sprintf("%s/%ss/%s", apiBaseUrl, conceptType, u),
+			PrefLabel:  fmt.Sprintf("Test concept %s %s", conceptType, u),
+			Types:      []string{ftGenreType},
+			DirectType: ftGenreType,
+			Aliases:    []string{},
+		}
+
+		ec.Index().
+			Index(indexName).
+			Type(conceptType).
+			Id(u).
+			BodyJson(payload).
+			Do(context.Background())
+
+		uuids = append(uuids, u)
+	}
+
+	// ensure test data is immediately available from the index
+	ec.Refresh(indexName).Do(context.Background())
+
+	return uuids
+}
+
+func TestFindAllConceptsByType(t *testing.T) {
+	esURL := getElasticSearchTestURL(t)
+
+	ec, err := elastic.NewClient(
+		elastic.SetURL(esURL),
+		elastic.SetSniff(false),
+	)
+	assert.NoError(t, err, "expected no error for ES client")
+
+	_ = writeTestConcepts(ec)
+
+	service := NewEsConceptSearchService(ec, indexName)
+	concepts, err := service.FindAllConceptsByType(ftGenreType)
+
+	assert.NoError(t, err, "expected no error for ES read")
+	assert.True(t, len(concepts) > 1, "there should be at least two genres")
+
+	var prev string
+	for i := range concepts {
+		if i > 0 {
+			assert.Equal(t, -1, strings.Compare(prev, concepts[i].PrefLabel), "concepts should be ordered")
+		}
+
+		prev = concepts[i].PrefLabel
+	}
+}
+
+func TestFindAllConceptsByTypeInvalid(t *testing.T) {
+	esURL := getElasticSearchTestURL(t)
+
+	ec, err := elastic.NewClient(
+		elastic.SetURL(esURL),
+		elastic.SetSniff(false),
+	)
+	assert.NoError(t, err, "expected no error for ES client")
+
+	service := NewEsConceptSearchService(ec, indexName)
+	_, err = service.FindAllConceptsByType("http://www.ft.com/ontology/Foo")
+
+	assert.Equal(t, ErrInvalidConceptType, err, "expected error for ES read")
+}

--- a/service/search_test.go
+++ b/service/search_test.go
@@ -2,13 +2,10 @@ package service
 
 import (
 	"context"
-	//	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
-	//	"sync"
 	"testing"
-	//	"time"
 
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"

--- a/service_test.go
+++ b/service_test.go
@@ -11,7 +11,7 @@ import (
 	"log"
 
 	"github.com/stretchr/testify/assert"
-	elastic "gopkg.in/olivere/elastic.v3"
+	elastic "gopkg.in/olivere/elastic.v5"
 )
 
 func TestConceptFinder(t *testing.T) {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -107,6 +107,14 @@
 			"versionExact": "v1.1.4"
 		},
 		{
+			"checksumSHA1": "NtqQXT/XuYBUDnOCC0kn4SXilkA=",
+			"path": "github.com/stretchr/testify/suite",
+			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
+            "revisionTime": "2016-09-25T01:54:16Z",
+            "version": "v1.1.4",
+            "versionExact": "v1.1.4"
+		},
+		{
 			"checksumSHA1": "Y+HGqEkYM15ir+J93MEaHdyFy0c=",
 			"path": "golang.org/x/net/context",
 			"revision": "10c134ea0df15f7e34d789338c7a2d76cc7a3ab9",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,81 +3,81 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "FUhczVSvt/VQAlWfzATo1YLez2E=",
+			"checksumSHA1": "4gy/7n/lgtdi5efuHXwFcIe1ZI8=",
 			"path": "github.com/Financial-Times/go-fthealth/v1a",
 			"revision": "f9074331b3ab48bca0e6d0afc211a673d88ac925",
 			"revisionTime": "2016-06-16T09:04:59Z"
 		},
 		{
-			"checksumSHA1": "zUpINnstJChGK0LAtkt7jBc3RY0=",
+			"checksumSHA1": "lBOK1zbqMz1rLNilYkkjPrjW+Qk=",
 			"path": "github.com/Financial-Times/http-handlers-go/httphandlers",
 			"revision": "bb69c454da9050fe1c4b92fe1345a01583ee70be",
 			"revisionTime": "2016-08-03T10:40:03Z"
 		},
 		{
-			"checksumSHA1": "ddLGmQTKn5BeEsKYFOGAH33sEfg=",
+			"checksumSHA1": "I/p6g4/ZiQhlPLRa9fFjzwuevwc=",
 			"path": "github.com/Financial-Times/transactionid-utils-go",
 			"revision": "a2b1163e7c2f6c77add74ca2c7fc7422323a2d78",
 			"revisionTime": "2016-02-12T16:38:35Z"
 		},
 		{
-			"checksumSHA1": "0Tugz8gj9KqqVj6JLkXUA7BXas4=",
+			"checksumSHA1": "ZCUKm9qDmTTGd+qutKuIdNsMS1Y=",
 			"path": "github.com/Sirupsen/logrus",
 			"revision": "0208149b40d863d2c1a2f8fe5753096a9cf2cc8b",
 			"revisionTime": "2017-02-27T12:44:09Z"
 		},
 		{
-			"checksumSHA1": "Lf3uUXTkKK5DJ37BxQvxO1Fq+K8=",
+			"checksumSHA1": "VgdO95xKa54YWKwGrKWvVnDXVOc=",
 			"origin": "github.com/stretchr/testify/vendor/github.com/davecgh/go-spew/spew",
 			"path": "github.com/davecgh/go-spew/spew",
 			"revision": "976c720a22c8eb4eb6a0b4348ad85ad12491a506",
 			"revisionTime": "2016-09-25T22:06:09Z"
 		},
 		{
-			"checksumSHA1": "iIUYZyoanCQQTUaWsu8b+iOSPt4=",
+			"checksumSHA1": "rk/QFSfmdW9TPNUWU6p5FUBIL3U=",
 			"path": "github.com/gorilla/context",
 			"revision": "aed02d124ae4a0e94fea4541c8effd05bf0c8296",
 			"revisionTime": "2016-05-25T20:33:19Z"
 		},
 		{
-			"checksumSHA1": "Ek5SW7pswB7YzX1Dr0bTSFCNOtc=",
+			"checksumSHA1": "cNq/Fd4f293e22341FG9VHGSZ+4=",
 			"path": "github.com/gorilla/mux",
 			"revision": "999ef73f5d50979cf6d12afed1726325b63f9570",
 			"revisionTime": "2017-02-23T20:25:54Z"
 		},
 		{
-			"checksumSHA1": "pYoO37aSFZl2uJAXpePBDnGItZc=",
+			"checksumSHA1": "rW0QSLVB0eUCzMdIL7yigeLBQ54=",
 			"path": "github.com/jawher/mow.cli",
 			"revision": "d3ffbc2f98b83e09dc8efd55ecec75eb5fd656ec",
 			"revisionTime": "2017-02-20T22:51:54Z"
 		},
 		{
-			"checksumSHA1": "ynJSWoF6v+3zMnh9R0QmmG6iGV8=",
+			"checksumSHA1": "iwLqOY6Nr1BitBUex4K0Wep3JL8=",
 			"path": "github.com/pkg/errors",
 			"revision": "248dadf4e9068a0b3e79f02ed0a610d935de5302",
 			"revisionTime": "2016-10-29T09:36:37Z"
 		},
 		{
-			"checksumSHA1": "zKKp5SZ3d3ycKe4EKMNT0BqAWBw=",
+			"checksumSHA1": "+oyIJwPyeof36XCkY8awrNfxaNM=",
 			"origin": "github.com/stretchr/testify/vendor/github.com/pmezard/go-difflib/difflib",
 			"path": "github.com/pmezard/go-difflib/difflib",
 			"revision": "976c720a22c8eb4eb6a0b4348ad85ad12491a506",
 			"revisionTime": "2016-09-25T22:06:09Z"
 		},
 		{
-			"checksumSHA1": "KAzbLjI9MzW2tjfcAsK75lVRp6I=",
+			"checksumSHA1": "DIjooF5+DLH5JSOjqnBlfNh9dFU=",
 			"path": "github.com/rcrowley/go-metrics",
 			"revision": "1f30fe9094a513ce4c700b9a54458bbb0c96996c",
 			"revisionTime": "2016-11-28T21:05:44Z"
 		},
 		{
-			"checksumSHA1": "iy7TNc01LWFOGwRwD6v0iDRqtLU=",
+			"checksumSHA1": "oNcjSQf1zGY27b9xipsqb2L4/RY=",
 			"path": "github.com/smartystreets/go-aws-auth",
 			"revision": "2043e6d0bb7e4c18464a7bba562acbe482e3cabd",
 			"revisionTime": "2016-07-22T04:48:03Z"
 		},
 		{
-			"checksumSHA1": "Q2V7Zs3diLmLfmfbiuLpSxETSuY=",
+			"checksumSHA1": "6RKpV2fKzhXl7aay5lelpiPljCY=",
 			"path": "github.com/stretchr/testify/assert",
 			"revision": "976c720a22c8eb4eb6a0b4348ad85ad12491a506",
 			"revisionTime": "2016-09-25T22:06:09Z"
@@ -95,22 +95,12 @@
 			"revisionTime": "2017-02-23T22:05:28Z"
 		},
 		{
-			"checksumSHA1": "hKfNq5lN9Sh3NpNZ3BBih0W+5yM=",
-			"path": "gopkg.in/olivere/elastic.v3",
-			"revision": "060365a7e27c56c938b234824ef7f9a3a7834b99",
-			"revisionTime": "2016-11-26T12:16:23Z"
-		},
-		{
-			"checksumSHA1": "lLdKOn9RPtFoTtPUNq5+sIInAiE=",
-			"path": "gopkg.in/olivere/elastic.v3/backoff",
-			"revision": "060365a7e27c56c938b234824ef7f9a3a7834b99",
-			"revisionTime": "2016-11-26T12:16:23Z"
-		},
-		{
-			"checksumSHA1": "XQg6xG6l15Ke43KolthYYnVDCYo=",
-			"path": "gopkg.in/olivere/elastic.v3/uritemplates",
-			"revision": "060365a7e27c56c938b234824ef7f9a3a7834b99",
-			"revisionTime": "2016-11-26T12:16:23Z"
+			"checksumSHA1": "qntQNbS1rti6r6O9SKw2Kfoc0kA=",
+			"path": "gopkg.in/olivere/elastic.v5",
+			"revision": "3f49414dc29d45ba96fde19ba72bc646077dbffd",
+			"revisionTime": "2017-05-15T15:52:10Z",
+			"version": "v5.0.38",
+			"versionExact": "v5.0.38"
 		}
 	],
 	"rootPath": "github.com/Financial-Times/concept-search-api"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -107,12 +107,20 @@
 			"versionExact": "v1.1.4"
 		},
 		{
-			"checksumSHA1": "NtqQXT/XuYBUDnOCC0kn4SXilkA=",
-			"path": "github.com/stretchr/testify/suite",
+			"checksumSHA1": "oqDuQM/+8vHvSt7f8w7WJfmHqws=",
+			"path": "github.com/stretchr/testify/require",
 			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
             "revisionTime": "2016-09-25T01:54:16Z",
             "version": "v1.1.4",
             "versionExact": "v1.1.4"
+		},
+		{
+			"checksumSHA1": "NtqQXT/XuYBUDnOCC0kn4SXilkA=",
+			"path": "github.com/stretchr/testify/suite",
+			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
+			"revisionTime": "2016-09-25T01:54:16Z",
+			"version": "v1.1.4",
+			"versionExact": "v1.1.4"
 		},
 		{
 			"checksumSHA1": "Y+HGqEkYM15ir+J93MEaHdyFy0c=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -101,7 +101,15 @@
 			"revisionTime": "2017-05-15T15:52:10Z",
 			"version": "v5.0.38",
 			"versionExact": "v5.0.38"
-		}
+		},
+		{
+            "checksumSHA1": "pCApZfp2CeDnWbNVsyzNO62ZUXA=",
+            "path": "gopkg.in/olivere/elastic.v5/uritemplates",
+            "revision": "3f49414dc29d45ba96fde19ba72bc646077dbffd",
+            "revisionTime": "2017-05-15T15:52:10Z",
+            "version": "v5.0.38",
+            "versionExact": "v5.0.38"
+        }
 	],
 	"rootPath": "github.com/Financial-Times/concept-search-api"
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -27,11 +27,11 @@
 			"revisionTime": "2017-02-27T12:44:09Z"
 		},
 		{
-			"checksumSHA1": "VgdO95xKa54YWKwGrKWvVnDXVOc=",
+			"checksumSHA1": "DuEyF75v9xaKXfJsCPRdHNOpGZk=",
 			"origin": "github.com/stretchr/testify/vendor/github.com/davecgh/go-spew/spew",
 			"path": "github.com/davecgh/go-spew/spew",
-			"revision": "976c720a22c8eb4eb6a0b4348ad85ad12491a506",
-			"revisionTime": "2016-09-25T22:06:09Z"
+			"revision": "cbd71e7dd4212e1fd8a2401873da279ebab0dca8",
+			"revisionTime": "2016-09-25T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "rk/QFSfmdW9TPNUWU6p5FUBIL3U=",
@@ -62,7 +62,7 @@
 			"origin": "github.com/stretchr/testify/vendor/github.com/pmezard/go-difflib/difflib",
 			"path": "github.com/pmezard/go-difflib/difflib",
 			"revision": "976c720a22c8eb4eb6a0b4348ad85ad12491a506",
-			"revisionTime": "2016-09-25T22:06:09Z"
+			"revisionTime": "2016-09-25T01:54:16Z"
 		},
 		{
 			"checksumSHA1": "DIjooF5+DLH5JSOjqnBlfNh9dFU=",
@@ -88,7 +88,17 @@
 			"checksumSHA1": "6RKpV2fKzhXl7aay5lelpiPljCY=",
 			"path": "github.com/stretchr/testify/assert",
 			"revision": "976c720a22c8eb4eb6a0b4348ad85ad12491a506",
-			"revisionTime": "2016-09-25T22:06:09Z"
+			"revisionTime": "2016-09-25T01:54:16Z",
+			"version": "v1.1.4",
+			"versionExact": "v1.1.4"
+		},
+		{
+			"checksumSHA1": "wjNVpZHpkT96ygOH5xN4rDfZdjE=",
+			"path": "github.com/stretchr/testify/mock",
+			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
+			"revisionTime": "2016-09-25T01:54:16Z",
+			"version": "v1.1.4",
+			"versionExact": "v1.1.4"
 		},
 		{
 			"checksumSHA1": "Y+HGqEkYM15ir+J93MEaHdyFy0c=",
@@ -111,7 +121,7 @@
 			"versionExact": "v5.0.38"
 		},
 		{
-			"checksumSHA1": "pCApZfp2CeDnWbNVsyzNO62ZUXA=",
+			"checksumSHA1": "x+ZyEkEsXKU47ycfEaegO0lxQpc=",
 			"path": "gopkg.in/olivere/elastic.v5/uritemplates",
 			"revision": "3f49414dc29d45ba96fde19ba72bc646077dbffd",
 			"revisionTime": "2017-05-15T15:52:10Z",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -85,6 +85,12 @@
 			"revisionTime": "2016-07-22T04:48:03Z"
 		},
 		{
+			"checksumSHA1": "ofNmmhhJAxYL1Mh09iq+utdfHIM=",
+			"path": "github.com/stretchr/objx",
+			"revision": "1a9d0bb9f541897e62256577b352fdbc1fb4fd94",
+			"revisionTime": "2015-09-28T12:21:52Z"
+		},
+		{
 			"checksumSHA1": "6RKpV2fKzhXl7aay5lelpiPljCY=",
 			"path": "github.com/stretchr/testify/assert",
 			"revision": "976c720a22c8eb4eb6a0b4348ad85ad12491a506",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -71,6 +71,14 @@
 			"revisionTime": "2016-11-28T21:05:44Z"
 		},
 		{
+			"checksumSHA1": "kg+yk3GiS678Sc6Xc+xrmGZRKxw=",
+			"path": "github.com/satori/go.uuid",
+			"revision": "f9ab0dce87d815821e221626b772e3475a0d2749",
+			"revisionTime": "2016-03-24T11:22:44Z",
+			"version": "v1.1.0",
+			"versionExact": "v1.1.0"
+		},
+		{
 			"checksumSHA1": "oNcjSQf1zGY27b9xipsqb2L4/RY=",
 			"path": "github.com/smartystreets/go-aws-auth",
 			"revision": "2043e6d0bb7e4c18464a7bba562acbe482e3cabd",
@@ -103,13 +111,13 @@
 			"versionExact": "v5.0.38"
 		},
 		{
-            "checksumSHA1": "pCApZfp2CeDnWbNVsyzNO62ZUXA=",
-            "path": "gopkg.in/olivere/elastic.v5/uritemplates",
-            "revision": "3f49414dc29d45ba96fde19ba72bc646077dbffd",
-            "revisionTime": "2017-05-15T15:52:10Z",
-            "version": "v5.0.38",
-            "versionExact": "v5.0.38"
-        }
+			"checksumSHA1": "pCApZfp2CeDnWbNVsyzNO62ZUXA=",
+			"path": "gopkg.in/olivere/elastic.v5/uritemplates",
+			"revision": "3f49414dc29d45ba96fde19ba72bc646077dbffd",
+			"revisionTime": "2017-05-15T15:52:10Z",
+			"version": "v5.0.38",
+			"versionExact": "v5.0.38"
+		}
 	],
 	"rootPath": "github.com/Financial-Times/concept-search-api"
 }


### PR DESCRIPTION
- Support get all concepts by type, if the concept type is mapped to a type for the ElasticSearch index. Presently only http://www.ft.com/ontology/Genre is mapped.
- Update to ElasticSearch version 5.
- Includes tests that run against a local ES. These can be skipped using `-short`.