### PR TITLE
changed the way documents without isDeprecated flag are queried

### DIFF
--- a/client.go
+++ b/client.go
@@ -11,7 +11,7 @@ import (
 )
 
 type esClient interface {
-	query(indexName string, query elastic.Query, resultLimit int, minScore float64) (*elastic.SearchResult, error)
+	query(indexName string, query elastic.Query, resultLimit int) (*elastic.SearchResult, error)
 	getClusterHealth() (*elastic.ClusterHealthResponse, error)
 }
 
@@ -58,10 +58,8 @@ func newElasticClient(accessKey string, secretKey string, endpoint *string, regi
 	return &esClientWrapper{elasticClient: elasticClient}, err
 }
 
-func (ec esClientWrapper) query(indexName string, query elastic.Query, resultLimit int, minScore float64) (*elastic.SearchResult, error) {
-	q := ec.elasticClient.Search().Index(indexName).Query(query)
-	q.MinScore(minScore)
-	return q.Size(resultLimit).Do(context.Background())
+func (ec esClientWrapper) query(indexName string, query elastic.Query, resultLimit int) (*elastic.SearchResult, error) {
+	return ec.elasticClient.Search().Index(indexName).Query(query).Size(resultLimit).Do(context.Background())
 }
 
 func (ec esClientWrapper) getClusterHealth() (*elastic.ClusterHealthResponse, error) {

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -258,7 +258,7 @@ type hcClient struct {
 	returnError error
 }
 
-func (c hcClient) query(indexName string, query elastic.Query, resultLimit int, minScore float64) (*elastic.SearchResult, error) {
+func (c hcClient) query(indexName string, query elastic.Query, resultLimit int) (*elastic.SearchResult, error) {
 	return &elastic.SearchResult{}, nil
 }
 

--- a/service.go
+++ b/service.go
@@ -69,13 +69,10 @@ func (service *esConceptFinder) FindConcept(writer http.ResponseWriter, request 
 
 	// by default {include_deprecated in (nil, false)} the deprecated entities are excluded
 	if !isDeprecatedIncluded(request) {
-		deprecationFilter := elastic.NewBoolQuery().MustNot(
-			elastic.NewTermQuery("isDeprecated", true),
-		)
-		finalQuery = finalQuery.Filter(deprecationFilter)
+		finalQuery = finalQuery.MustNot(elastic.NewTermQuery("isDeprecated", true))
 	}
 
-	searchResult, err := service.esClient().query(service.indexName, finalQuery, service.searchResultLimit, 0.0001) // just to force docs that are with score=0 not to be included in the final result set
+	searchResult, err := service.esClient().query(service.indexName, finalQuery, service.searchResultLimit)
 
 	if err != nil {
 		log.Errorf("There was an error executing the query on ES: %s", err.Error())

--- a/service_test.go
+++ b/service_test.go
@@ -207,7 +207,7 @@ func getElasticSearchTestURL(t *testing.T) string {
 
 type failClient struct{}
 
-func (tc failClient) query(indexName string, query elastic.Query, resultLimit int, minScore float64) (*elastic.SearchResult, error) {
+func (tc failClient) query(indexName string, query elastic.Query, resultLimit int) (*elastic.SearchResult, error) {
 	return &elastic.SearchResult{}, errors.New("Test ES failure")
 }
 
@@ -219,7 +219,7 @@ type mockClient struct {
 	queryResponse string
 }
 
-func (mc mockClient) query(indexName string, query elastic.Query, resultLimit int, minScore float64) (*elastic.SearchResult, error) {
+func (mc mockClient) query(indexName string, query elastic.Query, resultLimit int) (*elastic.SearchResult, error) {
 	var searchResult elastic.SearchResult
 	err := json.Unmarshal([]byte(mc.queryResponse), &searchResult)
 	if err != nil {


### PR DESCRIPTION
Changing the way documents without `isDeprecated` are excluded from results. Now `must_not` clause is used instead of `filter`.