### PR TITLE
Exact match capability on aliases field for all concept types

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,6 +12,7 @@ import (
 
 type esClient interface {
 	query(indexName string, query elastic.Query, resultLimit int) (*elastic.SearchResult, error)
+	multiSearchQuery(indexName string, searchRequests ...*elastic.SearchRequest) (*elastic.MultiSearchResult, error)
 	getClusterHealth() (*elastic.ClusterHealthResponse, error)
 }
 
@@ -64,4 +65,8 @@ func (ec esClientWrapper) query(indexName string, query elastic.Query, resultLim
 
 func (ec esClientWrapper) getClusterHealth() (*elastic.ClusterHealthResponse, error) {
 	return ec.elasticClient.ClusterHealth().Do(context.Background())
+}
+
+func (ec esClientWrapper) multiSearchQuery(indexName string, searchRequests ...*elastic.SearchRequest) (*elastic.MultiSearchResult, error) {
+	return ec.elasticClient.MultiSearch().Index(indexName).Add(searchRequests...).Do(context.Background())
 }

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -8,8 +8,8 @@ import (
 
 	fthealth "github.com/Financial-Times/go-fthealth/v1_1"
 	"github.com/Financial-Times/service-status-go/gtg"
-	log "github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"gopkg.in/olivere/elastic.v5"
 )
 

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -262,6 +262,10 @@ func (c hcClient) query(indexName string, query elastic.Query, resultLimit int) 
 	return &elastic.SearchResult{}, nil
 }
 
+func (c hcClient) multiSearchQuery(indexName string, searchRequests ...*elastic.SearchRequest) (*elastic.MultiSearchResult, error) {
+	return &elastic.MultiSearchResult{}, nil
+}
+
 func (c hcClient) getClusterHealth() (*elastic.ClusterHealthResponse, error) {
 	if c.returnError != nil {
 		return nil, c.returnError

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	fthealth "github.com/Financial-Times/go-fthealth/v1_1"
 	"github.com/Financial-Times/http-handlers-go/httphandlers"
 	status "github.com/Financial-Times/service-status-go/httphandlers"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/husobee/vestigo"
 	"github.com/jawher/mow.cli"
 	"github.com/rcrowley/go-metrics"

--- a/model.go
+++ b/model.go
@@ -13,6 +13,7 @@ type concept struct {
 	DirectType string   `json:"directType"`
 	Aliases    []string `json:"aliases,omitempty"`
 	Score      float64  `json:"score,omitempty"`
+	IsFTAuthor string   `json:"isFTAuthor,omitempty"`
 }
 
 type searchResult struct {

--- a/model.go
+++ b/model.go
@@ -30,5 +30,4 @@ type searchResult struct {
 type multiSearchWrapper struct {
 	term          string
 	searchRequest *elastic.SearchRequest
-	results       []concept
 }

--- a/model.go
+++ b/model.go
@@ -1,8 +1,8 @@
 package main
 
 type searchCriteria struct {
-	Term       *string  `json:"term"`
-	PrefLabels []string `json:"prefLabels"`
+	Term            *string  `json:"term"`
+	ExactMatchTerms []string `json:"exactMatchTerms"`
 }
 
 type concept struct {

--- a/model.go
+++ b/model.go
@@ -1,7 +1,8 @@
 package main
 
 type searchCriteria struct {
-	Term *string `json:"term"`
+	Term       *string  `json:"term"`
+	PrefLabels []string `json:"prefLabels"`
 }
 
 type concept struct {

--- a/model.go
+++ b/model.go
@@ -1,8 +1,15 @@
 package main
 
+import (
+	"gopkg.in/olivere/elastic.v5"
+)
+
 type searchCriteria struct {
-	Term            *string  `json:"term"`
-	ExactMatchTerms []string `json:"exactMatchTerms"`
+	Term           *string  `json:"term"`
+	BestMatchTerms []string `json:"bestMatchTerms"`
+	ConceptTypes   []string `json:"conceptTypes"`
+	BoostType      string   `json:"boost"`
+	FilterType     string   `json:"filter"`
 }
 
 type concept struct {
@@ -18,4 +25,10 @@ type concept struct {
 
 type searchResult struct {
 	Results []concept `json:"results"`
+}
+
+type multiSearchWrapper struct {
+	term          string
+	searchRequest *elastic.SearchRequest
+	results       []concept
 }

--- a/resources/handler_test.go
+++ b/resources/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Financial-Times/concept-search-api/service"
+	"github.com/Financial-Times/concept-search-api/util"
 	"github.com/husobee/vestigo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -17,7 +18,7 @@ import (
 )
 
 var (
-	expectedInputErr = service.NewInputError("computer says no")
+	expectedInputErr = util.NewInputError("computer says no")
 )
 
 type mockConceptSearchService struct {
@@ -116,7 +117,7 @@ func TestAllConceptByTypeNoElasticsearchError(t *testing.T) {
 func TestAllConceptByTypeNoElasticsearchClientError(t *testing.T) {
 	req := httptest.NewRequest("GET", "/concepts?type=http%3A%2F%2Fwww.ft.com%2Fontology%2FFoo", nil)
 	svc := &mockConceptSearchService{}
-	svc.On("FindAllConceptsByType", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return([]service.Concept{}, service.ErrNoElasticClient)
+	svc.On("FindAllConceptsByType", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return([]service.Concept{}, util.ErrNoElasticClient)
 
 	actual := doHttpCall(svc, req)
 
@@ -125,7 +126,7 @@ func TestAllConceptByTypeNoElasticsearchClientError(t *testing.T) {
 
 	respObject := unmarshallResponseMessage(t, actual)
 
-	assert.Equal(t, service.ErrNoElasticClient.Error(), respObject["message"], "error message")
+	assert.Equal(t, util.ErrNoElasticClient.Error(), respObject["message"], "error message")
 }
 
 func TestAllConceptByTypeServerError(t *testing.T) {
@@ -389,7 +390,7 @@ func TestConceptsByIdNoElasticsearchError(t *testing.T) {
 func TestConceptsByIdNoElasticsearchClientError(t *testing.T) {
 	req := httptest.NewRequest("GET", "/concepts?ids=1&ids=2", nil)
 	svc := &mockConceptSearchService{}
-	svc.On("FindConceptsById", []string{"1", "2"}).Return([]service.Concept{}, service.ErrNoElasticClient)
+	svc.On("FindConceptsById", []string{"1", "2"}).Return([]service.Concept{}, util.ErrNoElasticClient)
 
 	actual := doHttpCall(svc, req)
 
@@ -398,7 +399,7 @@ func TestConceptsByIdNoElasticsearchClientError(t *testing.T) {
 
 	respObject := unmarshallResponseMessage(t, actual)
 
-	assert.Equal(t, service.ErrNoElasticClient.Error(), respObject["message"], "error message")
+	assert.Equal(t, util.ErrNoElasticClient.Error(), respObject["message"], "error message")
 }
 
 func TestConceptsByIdServerError(t *testing.T) {

--- a/service.go
+++ b/service.go
@@ -154,12 +154,16 @@ func isDeprecatedIncluded(request *http.Request) bool {
 }
 
 func isFTAuthorIncluded(request *http.Request) bool {
-	queryParam := request.URL.Query().Get("include_ft_author")
-	includeFtAuthor, err := strconv.ParseBool(queryParam)
-	if err != nil {
-		return false
+	return isFieldIncluded(request, "authors")
+}
+
+func isFieldIncluded(request *http.Request, fieldValue string) bool {
+	for _, field := range request.URL.Query()["include_field"] {
+		if field == fieldValue {
+			return true
+		}
 	}
-	return includeFtAuthor
+	return false
 }
 
 func isScoreIncluded(request *http.Request) bool {

--- a/service.go
+++ b/service.go
@@ -187,7 +187,7 @@ func createQueryForExactPrefLabel(request *http.Request, criteria *searchCriteri
 	for _, prefLabel := range criteria.PrefLabels {
 		currentPrefLabelQueries := []elastic.Query{}
 		for _, prefLabelTerm := range strings.Fields(prefLabel) {
-			currentPrefLabelQueries = append(currentPrefLabelQueries, elastic.NewMatchQuery("prefLabel.edge_ngram", prefLabelTerm))
+			currentPrefLabelQueries = append(currentPrefLabelQueries, elastic.NewMatchQuery("aliases", prefLabelTerm))
 		}
 		prefLabelsQ = append(prefLabelsQ, elastic.NewBoolQuery().Must(currentPrefLabelQueries...))
 	}

--- a/service.go
+++ b/service.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/Financial-Times/concept-search-api/util"
 	"github.com/Financial-Times/transactionid-utils-go"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"gopkg.in/olivere/elastic.v5"
 )
 

--- a/service.go
+++ b/service.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -99,7 +98,7 @@ func (service *esConceptFinder) findConceptsWithTerm(writer http.ResponseWriter,
 	defer func() {
 		// searchResult.Hits.TotalHits call panics if the result from ES is not a valid JSON, this handles it
 		if r := recover(); r != nil {
-			fmt.Println("Recovered in findConcept", r)
+			log.WithField("Recover", r).Error("Recovered in findConcept")
 			writer.WriteHeader(http.StatusInternalServerError)
 		}
 	}()

--- a/service.go
+++ b/service.go
@@ -288,6 +288,7 @@ func getBoostQuery(boostType string, conceptTypes []string) (elastic.Query, erro
 		if err != nil {
 			return nil, err
 		}
+		// got from search.go#searchConceptsForMultipleTypes - not random 1.8 value. It was tunned in there
 		return elastic.NewTermQuery("isFTAuthor", "true").Boost(1.8), nil
 	default:
 		return nil, util.ErrInvalidBoostTypeParameter

--- a/service/es_client.go
+++ b/service/es_client.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	awsauth "github.com/smartystreets/go-aws-auth"
 	"gopkg.in/olivere/elastic.v5"
 )

--- a/service/model.go
+++ b/service/model.go
@@ -29,15 +29,6 @@ type Concept struct {
 type Concepts []Concept
 
 var (
-	esTypeMapping = map[string]string{
-		"http://www.ft.com/ontology/Genre":                     "genres",
-		"http://www.ft.com/ontology/product/Brand":             "brands",
-		"http://www.ft.com/ontology/person/Person":             "people",
-		"http://www.ft.com/ontology/organisation/Organisation": "organisations",
-		"http://www.ft.com/ontology/Location":                  "locations",
-		"http://www.ft.com/ontology/Topic":                     "topics",
-	}
-
 	incorrectPath = "http://api.ft.com/things/"
 )
 
@@ -59,25 +50,11 @@ func ConvertToSimpleConcept(esConcept EsConceptModel) Concept {
 	return c
 }
 
-func esType(ftType string) string {
-	return esTypeMapping[ftType]
-}
-
 func correctPath(id string) string {
 	if strings.HasPrefix(id, incorrectPath) {
 		return strings.Replace(id, incorrectPath, "http://www.ft.com/thing/", 1)
 	}
 	return id
-}
-
-func ftType(esType string) string {
-	for k, v := range esTypeMapping {
-		if v == esType {
-			return k
-		}
-	}
-
-	return ""
 }
 
 func (slice Concepts) Len() int {

--- a/service/model.go
+++ b/service/model.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type EsConceptModel struct {

--- a/service/model_test.go
+++ b/service/model_test.go
@@ -38,16 +38,6 @@ func TestConceptsSortInterface(t *testing.T) {
 	assert.False(t, concepts.Less(0, 1), "concept ordering by prefLabel")
 }
 
-func TestEsType(t *testing.T) {
-	assert.Equal(t, "genres", esType("http://www.ft.com/ontology/Genre"), "known type conversion")
-	assert.Equal(t, "", esType("http://www.ft.com/ontology/Foo"), "unknown type conversion")
-}
-
-func TestFtType(t *testing.T) {
-	assert.Equal(t, "http://www.ft.com/ontology/Genre", ftType("genres"), "known type conversion")
-	assert.Equal(t, "", ftType("tardigrades"), "unknown type conversion")
-}
-
 func TestConvertToSimpleConcept(t *testing.T) {
 	id := "http://www.ft.com/thing/id"
 	apiUrl := "http://www.example.com/1"

--- a/service/search.go
+++ b/service/search.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/Financial-Times/concept-search-api/util"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"gopkg.in/olivere/elastic.v5"
 )
 

--- a/service/search_test.go
+++ b/service/search_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Financial-Times/concept-search-api/util"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,10 +38,10 @@ func TestNoElasticClient(t *testing.T) {
 	service := NewEsConceptSearchService("test", 50, 10, 2)
 
 	_, err := service.FindAllConceptsByType(ftGenreType, true)
-	assert.EqualError(t, err, ErrNoElasticClient.Error(), "error response")
+	assert.EqualError(t, err, util.ErrNoElasticClient.Error(), "error response")
 
 	_, err = service.SearchConceptByTextAndTypes("lucy", []string{ftBrandType}, true)
-	assert.EqualError(t, err, ErrNoElasticClient.Error(), "error response")
+	assert.EqualError(t, err, util.ErrNoElasticClient.Error(), "error response")
 }
 
 type EsConceptSearchServiceTestSuite struct {
@@ -281,7 +282,7 @@ func (s *EsConceptSearchServiceTestSuite) TestFindAllConceptsByTypeInvalid() {
 
 	_, err := service.FindAllConceptsByType("http://www.ft.com/ontology/Foo", true)
 
-	assert.EqualError(s.T(), err, fmt.Sprintf(errInvalidConceptTypeFormat, "http://www.ft.com/ontology/Foo"), "expected error")
+	assert.EqualError(s.T(), err, fmt.Sprintf(util.ErrInvalidConceptTypeFormat, "http://www.ft.com/ontology/Foo"), "expected error")
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestFindAllConceptsByTypeDeprecatedFlag() {
@@ -480,7 +481,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesNoConce
 	service.SetElasticClient(s.ec)
 
 	_, err := service.SearchConceptByTextAndTypes("pippo", []string{}, true)
-	assert.EqualError(s.T(), err, errNoConceptTypeParameter.Error())
+	assert.EqualError(s.T(), err, util.ErrNoConceptTypeParameter.Error())
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesInvalidConceptType() {
@@ -488,7 +489,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesInvalid
 	service.SetElasticClient(s.ec)
 
 	_, err := service.SearchConceptByTextAndTypes("pippo", []string{"http://www.ft.com/ontology/Foo"}, true)
-	assert.EqualError(s.T(), err, fmt.Sprintf(errInvalidConceptTypeFormat, "http://www.ft.com/ontology/Foo"))
+	assert.EqualError(s.T(), err, fmt.Sprintf(util.ErrInvalidConceptTypeFormat, "http://www.ft.com/ontology/Foo"))
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesTermMatchBoosted() {
@@ -778,7 +779,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoo
 	service.SetElasticClient(s.ec)
 
 	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{}, "authors", true)
-	assert.EqualError(s.T(), err, errNoConceptTypeParameter.Error())
+	assert.EqualError(s.T(), err, util.ErrNoConceptTypeParameter.Error())
 	assert.Nil(s.T(), concepts)
 }
 
@@ -787,7 +788,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoo
 	service.SetElasticClient(s.ec)
 
 	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{ftPeopleType, ftLocationType}, "authors", true)
-	assert.EqualError(s.T(), err, errNotSupportedCombinationOfConceptTypes.Error())
+	assert.EqualError(s.T(), err, util.ErrNotSupportedCombinationOfConceptTypes.Error())
 	assert.Nil(s.T(), concepts)
 }
 
@@ -796,7 +797,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithInv
 	service.SetElasticClient(s.ec)
 
 	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{ftPeopleType}, "pluto", true)
-	assert.EqualError(s.T(), err, errInvalidBoostTypeParameter.Error())
+	assert.EqualError(s.T(), err, util.ErrInvalidBoostTypeParameter.Error())
 	assert.Nil(s.T(), concepts)
 }
 
@@ -804,7 +805,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoo
 	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
 
 	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{ftPeopleType}, "authors", true)
-	assert.EqualError(s.T(), err, ErrNoElasticClient.Error())
+	assert.EqualError(s.T(), err, util.ErrNoElasticClient.Error())
 	assert.Nil(s.T(), concepts)
 }
 
@@ -812,6 +813,6 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoo
 	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
 
 	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{ftGenreType}, "authors", true)
-	assert.EqualError(s.T(), err, fmt.Sprintf(errInvalidConceptTypeFormat, ftGenreType))
+	assert.EqualError(s.T(), err, fmt.Sprintf(util.ErrInvalidConceptTypeFormat, ftGenreType))
 	assert.Nil(s.T(), concepts)
 }

--- a/service_test.go
+++ b/service_test.go
@@ -236,7 +236,7 @@ func TestConceptFinderForExactMatch(t *testing.T) {
 				queryResponse: validResponseExactMatch,
 			},
 			returnCode:    http.StatusOK,
-			requestURL:    defaultRequestURL + "?type=http://www.ft.com/ontology/person/Person&include_ft_author=true",
+			requestURL:    defaultRequestURL + "?type=http://www.ft.com/ontology/person/Person&include_field=authors",
 			requestBody:   `{"exactMatchTerms":["Eric Platt","Michael Hunter","Adam Samson"]}`,
 			expectedUUIDs: []string{"f758ef56-c40a-3162-91aa-3e8a3aabc494", "64302452-e369-4ddb-88fa-9adc5124a38c", "9332270e-f959-3f55-9153-d30acd0d0a51", "40281396-8369-4699-ae48-1ccc0c931a72"},
 			expectedScore: []float64{28.629284, 28.060131, 25.467949, 15.63516},

--- a/service_test.go
+++ b/service_test.go
@@ -153,7 +153,7 @@ func TestConceptFinder(t *testing.T) {
 	}
 }
 
-func TestConceptFinderForExactMatch(t *testing.T) {
+func TestConceptFinderForBestMatch(t *testing.T) {
 
 	testCases := []struct {
 		testName            string
@@ -161,99 +161,169 @@ func TestConceptFinderForExactMatch(t *testing.T) {
 		returnCode          int
 		requestURL          string
 		requestBody         string
-		expectedUUIDs       []string
-		expectedScore       []float64
-		extraAssertionLogic func(t *testing.T, searchResults searchResult)
+		expectedUUIDs       map[string][]string
+		extraAssertionLogic func(t *testing.T, searchResults map[string][]concept)
 	}{
 		{
-			testName:      "TooMuchDataInPayload",
-			client:        mockClient{},
-			returnCode:    http.StatusBadRequest,
-			requestURL:    defaultRequestURL,
-			requestBody:   `{"term":"Foobar", "exactMatchTerms":["testTerm"]}`,
-			expectedScore: nil,
+			testName:    "TooMuchDataInPayload",
+			client:      mockClient{},
+			returnCode:  http.StatusBadRequest,
+			requestURL:  defaultRequestURL,
+			requestBody: `{"term":"Foobar", "bestMatchTerms":["testTerm"]}`,
 		},
 		{
-			testName:      "WrongType",
-			client:        mockClient{},
-			returnCode:    http.StatusBadRequest,
-			requestURL:    defaultRequestURL + "?type=http://www.ft.com/ontology/organisation/NotExisting",
-			requestBody:   `{"exactMatchTerms":["testTerm"]}`,
-			expectedScore: nil,
+			testName:    "WrongType",
+			client:      mockClient{},
+			returnCode:  http.StatusBadRequest,
+			requestURL:  defaultRequestURL,
+			requestBody: `{"bestMatchTerms":["testTerm"], "conceptTypes": ["http://www.ft.com/ontology/organisation/NotExisting"]}`,
 		},
 		{
-			testName:      "WrongBoost",
-			client:        mockClient{},
-			returnCode:    http.StatusBadRequest,
-			requestURL:    defaultRequestURL + "?boost=wrong_boost",
-			requestBody:   `{"exactMatchTerms":["testTerm"]}`,
-			expectedScore: nil,
+			testName:    "WrongBoost",
+			client:      mockClient{},
+			returnCode:  http.StatusBadRequest,
+			requestURL:  defaultRequestURL,
+			requestBody: `{"bestMatchTerms":["testTerm"], "boost":"wrong_boost"}`,
 		},
 		{
-			testName:      "WrongBoostTypeCombination",
-			client:        mockClient{},
-			returnCode:    http.StatusBadRequest,
-			requestURL:    defaultRequestURL + "?boost=authors&type=http://www.ft.com/ontology/organisation/Organisation",
-			requestBody:   `{"exactMatchTerms":["testTerm"]}`,
-			expectedScore: nil,
+			testName:    "WrongBoostTypeCombination",
+			client:      mockClient{},
+			returnCode:  http.StatusBadRequest,
+			requestURL:  defaultRequestURL,
+			requestBody: `{"bestMatchTerms":["testTerm"], "boost":"wrong_boost","conceptTypes": ["http://www.ft.com/ontology/organisation/Organisation"]}`,
 		},
 		{
-			testName:      "WrongFilterTypeCombination",
-			client:        mockClient{},
-			returnCode:    http.StatusBadRequest,
-			requestURL:    defaultRequestURL + "?filter=authors&type=http://www.ft.com/ontology/organisation/Organisation",
-			requestBody:   `{"exactMatchTerms":["testTerm"]}`,
-			expectedScore: nil,
+			testName:    "WrongFilterTypeCombination",
+			client:      mockClient{},
+			returnCode:  http.StatusBadRequest,
+			requestURL:  defaultRequestURL,
+			requestBody: `{"bestMatchTerms":["testTerm"], "filter": "authors", "conceptTypes": ["http://www.ft.com/ontology/organisation/Organisation"]}`,
 		},
 		{
-			testName:      "BoostWithoutType",
-			client:        mockClient{},
-			returnCode:    http.StatusBadRequest,
-			requestURL:    defaultRequestURL + "?boost=authors",
-			requestBody:   `{"exactMatchTerms":["testTerm"]}`,
-			expectedScore: nil,
+			testName:    "BoostWithoutType",
+			client:      mockClient{},
+			returnCode:  http.StatusBadRequest,
+			requestURL:  defaultRequestURL,
+			requestBody: `{"bestMatchTerms":["testTerm"], "boost": "authors"}`,
+		},
+		{
+			testName:    "ErrorFromES",
+			client:      failClient{},
+			returnCode:  http.StatusInternalServerError,
+			requestURL:  defaultRequestURL,
+			requestBody: `{"bestMatchTerms":["testTerm"]}`,
 		},
 		{
 			testName: "OkPeopleType",
 			client: mockClient{
-				queryResponse: validResponseExactMatch,
+				queryResponse: validResponseBestMatch,
 			},
-			returnCode:    http.StatusOK,
-			requestURL:    defaultRequestURL + "?type=http://www.ft.com/ontology/person/Person",
-			requestBody:   `{"exactMatchTerms":["Eric Platt","Michael Hunter","Adam Samson"]}`,
-			expectedUUIDs: []string{"f758ef56-c40a-3162-91aa-3e8a3aabc494", "64302452-e369-4ddb-88fa-9adc5124a38c", "9332270e-f959-3f55-9153-d30acd0d0a51", "40281396-8369-4699-ae48-1ccc0c931a72"},
-			expectedScore: []float64{28.629284, 28.060131, 25.467949, 15.63516},
-			extraAssertionLogic: func(t *testing.T, searchResults searchResult) {
-				for _, res := range searchResults.Results {
-					_, err := strconv.ParseBool(res.IsFTAuthor)
-					assert.Error(t, err, "isFtAuthor shouldn't be included")
+			returnCode:  http.StatusOK,
+			requestURL:  defaultRequestURL,
+			requestBody: `{"bestMatchTerms":["Adam Samson", "Eric Platt", "Michael Hunter"], "conceptTypes": ["http://www.ft.com/ontology/person/Person"]}`,
+			expectedUUIDs: map[string][]string{
+				"Adam Samson": []string{
+					"f758ef56-c40a-3162-91aa-3e8a3aabc494",
+				},
+				"Eric Platt": []string{
+					"40281396-8369-4699-ae48-1ccc0c931a72",
+				},
+				"Michael Hunter": []string{
+					"9332270e-f959-3f55-9153-d30acd0d0a51",
+				},
+			},
+			extraAssertionLogic: func(t *testing.T, searchResults map[string][]concept) {
+				for _, concepts := range searchResults {
+					for _, res := range concepts {
+						_, err := strconv.ParseBool(res.IsFTAuthor)
+						assert.Error(t, err, "isFtAuthor shouldn't be included")
+					}
+				}
+			},
+		},
+		{
+			testName: "OkPeopleTypePartialResults",
+			client: mockClient{
+				queryResponse: validResponseBestMatchPartialResults,
+			},
+			returnCode:  http.StatusOK,
+			requestURL:  defaultRequestURL,
+			requestBody: `{"bestMatchTerms":["Adam Samson", "Eric Platt", "Michael Hunter"], "conceptTypes": ["http://www.ft.com/ontology/person/Person"]}`,
+			expectedUUIDs: map[string][]string{
+				"Adam Samson": []string{
+					"f758ef56-c40a-3162-91aa-3e8a3aabc494",
+				},
+				"Eric Platt": []string{},
+				"Michael Hunter": []string{
+					"9332270e-f959-3f55-9153-d30acd0d0a51",
+				},
+			},
+			extraAssertionLogic: func(t *testing.T, searchResults map[string][]concept) {
+				for _, concepts := range searchResults {
+					for _, res := range concepts {
+						_, err := strconv.ParseBool(res.IsFTAuthor)
+						assert.Error(t, err, "isFtAuthor shouldn't be included")
+					}
+				}
+			},
+		},
+		{
+			testName: "OkPeopleTypeNoResults",
+			client: mockClient{
+				queryResponse: validResponseBestMatchNoResults,
+			},
+			returnCode:  http.StatusNotFound,
+			requestURL:  defaultRequestURL,
+			requestBody: `{"bestMatchTerms":["Adam Samson", "Eric Platt", "Michael Hunter"], "conceptTypes": ["http://www.ft.com/ontology/person/Person"]}`,
+			expectedUUIDs: map[string][]string{
+				"Adam Samson":    []string{},
+				"Eric Platt":     []string{},
+				"Michael Hunter": []string{},
+			},
+			extraAssertionLogic: func(t *testing.T, searchResults map[string][]concept) {
+				for _, concepts := range searchResults {
+					for _, res := range concepts {
+						_, err := strconv.ParseBool(res.IsFTAuthor)
+						assert.Error(t, err, "isFtAuthor shouldn't be included")
+					}
 				}
 			},
 		},
 		{
 			testName: "IncludeFtAuthorQueryParam",
 			client: mockClient{
-				queryResponse: validResponseExactMatch,
+				queryResponse: validResponseBestMatch,
 			},
-			returnCode:    http.StatusOK,
-			requestURL:    defaultRequestURL + "?type=http://www.ft.com/ontology/person/Person&include_field=authors",
-			requestBody:   `{"exactMatchTerms":["Eric Platt","Michael Hunter","Adam Samson"]}`,
-			expectedUUIDs: []string{"f758ef56-c40a-3162-91aa-3e8a3aabc494", "64302452-e369-4ddb-88fa-9adc5124a38c", "9332270e-f959-3f55-9153-d30acd0d0a51", "40281396-8369-4699-ae48-1ccc0c931a72"},
-			expectedScore: []float64{28.629284, 28.060131, 25.467949, 15.63516},
-			extraAssertionLogic: func(t *testing.T, searchResults searchResult) {
+			returnCode:  http.StatusOK,
+			requestURL:  defaultRequestURL + "?include_field=authors",
+			requestBody: `{"bestMatchTerms":["Adam Samson", "Eric Platt", "Michael Hunter"], "conceptTypes": ["http://www.ft.com/ontology/person/Person"]}`,
+			expectedUUIDs: map[string][]string{
+				"Adam Samson": []string{
+					"f758ef56-c40a-3162-91aa-3e8a3aabc494",
+				},
+				"Eric Platt": []string{
+					"40281396-8369-4699-ae48-1ccc0c931a72",
+				},
+				"Michael Hunter": []string{
+					"9332270e-f959-3f55-9153-d30acd0d0a51",
+				},
+			},
+			extraAssertionLogic: func(t *testing.T, searchResults map[string][]concept) {
 				notAuthorCounter := 0
 				authorCounter := 0
-				for _, res := range searchResults.Results {
-					isFtAuthor, err := strconv.ParseBool(res.IsFTAuthor)
-					assert.NoError(t, err)
-					if isFtAuthor {
-						authorCounter++
-					} else {
-						notAuthorCounter++
+				for _, concepts := range searchResults {
+					for _, res := range concepts {
+						isFtAuthor, err := strconv.ParseBool(res.IsFTAuthor)
+						assert.NoError(t, err)
+						if isFtAuthor {
+							authorCounter++
+						} else {
+							notAuthorCounter++
+						}
 					}
 				}
 				assert.Equal(t, 1, notAuthorCounter)
-				assert.Equal(t, 3, authorCounter)
+				assert.Equal(t, 2, authorCounter)
 			},
 		},
 	}
@@ -276,19 +346,15 @@ func TestConceptFinderForExactMatch(t *testing.T) {
 			continue
 		}
 
-		var searchResults searchResult
+		var searchResults map[string][]concept
 		err := json.Unmarshal(w.Body.Bytes(), &searchResults)
 		assert.Equal(t, nil, err, "%s -> expected no error", testCase.testName)
-		assert.Equal(t, len(testCase.expectedUUIDs), len(searchResults.Results), "%s -> different no. of results", testCase.testName)
-
-		for i, uuid := range testCase.expectedUUIDs {
-			assert.True(t, strings.Contains(searchResults.Results[i].ID, uuid), "%s -> uuid expectation", testCase.testName)
-		}
-
-		if testCase.requestURL == requestURLWithScore ||
-			testCase.requestURL == requestURLWithScoreAndDeprecated {
-			for i, score := range testCase.expectedScore {
-				assert.Equal(t, score, searchResults.Results[i].Score, "%s -> score expectation", testCase.testName)
+		assert.Equal(t, len(testCase.expectedUUIDs), len(searchResults), "%s -> different no. of results", testCase.testName)
+		for searchTerm, searchTermExpectedUUIDs := range testCase.expectedUUIDs {
+			actualTermUUIDs, ok := searchResults[searchTerm]
+			assert.True(t, ok, "%s -> expected values for %s", testCase.testName, searchTerm)
+			for i, uuid := range searchTermExpectedUUIDs {
+				assert.Contains(t, actualTermUUIDs[i].ID, uuid, "%s -> uuid expectation", testCase.testName)
 			}
 		}
 
@@ -340,7 +406,7 @@ func TestEsQueryScore(t *testing.T) {
 	assert.Equal(t, "Anna Whitwham", searchResults.Results[0].PrefLabel)
 }
 
-func TestEsExactMatchImpl(t *testing.T) {
+func TestEsBestMatchImpl(t *testing.T) {
 	// create ES client
 	ec, err := elastic.NewClient(
 		elastic.SetURL(getElasticSearchTestURL(t)),
@@ -349,59 +415,69 @@ func TestEsExactMatchImpl(t *testing.T) {
 	assert.NoError(t, err, "expected no error for ES client")
 
 	// cleanup for accuracy
-	ec.DeleteIndex(exactMatchIndexName).Do(context.Background())
-	err = createIndex(ec, "service/test/mapping.json", exactMatchIndexName)
+	ec.DeleteIndex(bestMatchIndexName).Do(context.Background())
+	err = createIndex(ec, "service/test/mapping.json", bestMatchIndexName)
 
 	// store testing data
-	for uuid, conceptBody := range exactMatchTestingData {
+	for uuid, conceptBody := range bestMatchTestingData {
 		_, e := ec.Index().
-			Index(exactMatchIndexName).
+			Index(bestMatchIndexName).
 			Type("people").
 			BodyString(conceptBody).
 			Id(uuid).
 			Do(context.Background())
 		assert.NoError(t, e, "expected no error for ES client")
 	}
-	ec.Refresh(exactMatchIndexName).Do(context.TODO())
+	ec.Refresh(bestMatchIndexName).Do(context.TODO())
 
 	// prepare request and trigger this
-	req, _ := http.NewRequest("POST", "http://dummy_host/concepts?type=http://www.ft.com/ontology/person/Person", strings.NewReader(`
+	req, _ := http.NewRequest("POST", "http://dummy_host/concepts?include_deprecated=true", strings.NewReader(`
 		{
-			"exactMatchTerms":[
+			"bestMatchTerms":[
 				"Platt Eric",
 				"Michael Hunter",
 				"Samson Adam"
-			]
+			],
+			"conceptTypes": ["http://www.ft.com/ontology/person/Person"]
 		}`))
 	w := httptest.NewRecorder()
-	conceptFinder := newConceptFinder(exactMatchIndexName, 10)
+	conceptFinder := newConceptFinder(bestMatchIndexName, 10)
 	conceptFinder.SetElasticClient(ec)
 	conceptFinder.FindConcept(w, req)
 
 	// check
 	assert.Equal(t, http.StatusOK, w.Code)
-	var searchResults searchResult
+	var searchResults map[string][]concept
 	err = json.Unmarshal(w.Body.Bytes(), &searchResults)
 	assert.Equal(t, nil, err)
-	assert.Len(t, searchResults.Results, 3)
-	counter := 0
-	for _, res := range searchResults.Results {
-		if res.PrefLabel == "Eric Platt" ||
-			res.PrefLabel == "Michael Hunter" ||
-			res.PrefLabel == "Adam Samson" {
-			counter++
-		}
-	}
-	assert.Equal(t, 3, counter)
+	assert.Len(t, searchResults, 3)
 
-	// check for `boost` queryParam
-	req, _ = http.NewRequest("POST", "http://dummy_host/concepts?type=http://www.ft.com/ontology/person/Person&include_deprecated=true&boost=authors", strings.NewReader(`
+	// assert for uuids
+	ericPlattConcepts, ok := searchResults["Platt Eric"]
+	assert.True(t, ok, "expected results for Platt Eric")
+	assert.Len(t, ericPlattConcepts, 1, "expected 1 concept for Platt Eric")
+	assert.Equal(t, "http://api.ft.com/things/64302452-e369-4ddb-88fa-9adc5124a38c", ericPlattConcepts[0].ID)
+
+	adamSamsonConcepts, ok := searchResults["Samson Adam"]
+	assert.True(t, ok, "expected results for Adam Samson")
+	assert.Len(t, adamSamsonConcepts, 1, "expected 1 concept for Adam Samson")
+	assert.Equal(t, "http://api.ft.com/things/f758ef56-c40a-3162-91aa-3e8a3aabc494", adamSamsonConcepts[0].ID)
+
+	michaelHunterConcepts, ok := searchResults["Michael Hunter"]
+	assert.True(t, ok, "expected results for Michael Hunter")
+	assert.Len(t, michaelHunterConcepts, 1, "expected 1 concept for Michael Hunter")
+	assert.Equal(t, "http://api.ft.com/things/9332270e-f959-3f55-9153-d30acd0d0a51", michaelHunterConcepts[0].ID)
+
+	// check for `boost`
+	req, _ = http.NewRequest("POST", "http://dummy_host/concepts", strings.NewReader(`
 		{
-			"exactMatchTerms":[
+			"bestMatchTerms":[
 				"Platt Eric",
 				"Michael Hunter",
 				"Samson Adam"
-			]
+			],
+			"conceptTypes": ["http://www.ft.com/ontology/person/Person"],
+			"boost": "authors"
 		}`))
 	w = httptest.NewRecorder()
 	conceptFinder.FindConcept(w, req)
@@ -410,25 +486,33 @@ func TestEsExactMatchImpl(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	err = json.Unmarshal(w.Body.Bytes(), &searchResults)
 	assert.Equal(t, nil, err)
-	assert.Len(t, searchResults.Results, 4)
-	counter = 0
-	for _, res := range searchResults.Results {
-		if res.PrefLabel == "Eric Platt" ||
-			res.PrefLabel == "Michael Hunter" ||
-			res.PrefLabel == "Adam Samson" {
-			counter++
-		}
-	}
-	assert.Equal(t, 4, counter) // two "Eric Platt" concepts - one with ftAuthor=false and one with ftAuthor=true
+	assert.Len(t, searchResults, 3)
 
-	// check for `boost` queryParam
-	req, _ = http.NewRequest("POST", "http://dummy_host/concepts?type=http://www.ft.com/ontology/person/Person&include_deprecated=true&filter=authors", strings.NewReader(`
+	ericPlattConcepts, ok = searchResults["Platt Eric"]
+	assert.True(t, ok, "expected results for Platt Eric")
+	assert.Len(t, ericPlattConcepts, 1, "expected 1 concept for Platt Eric")
+	assert.Equal(t, "http://api.ft.com/things/64302452-e369-4ddb-88fa-9adc5124a38c", ericPlattConcepts[0].ID)
+
+	adamSamsonConcepts, ok = searchResults["Samson Adam"]
+	assert.True(t, ok, "expected results for Adam Samson")
+	assert.Len(t, adamSamsonConcepts, 1, "expected 1 concept for Adam Samson")
+	assert.Equal(t, "http://api.ft.com/things/f758ef56-c40a-3162-91aa-3e8a3aabc494", adamSamsonConcepts[0].ID)
+
+	michaelHunterConcepts, ok = searchResults["Michael Hunter"]
+	assert.True(t, ok, "expected results for Michael Hunter")
+	assert.Len(t, michaelHunterConcepts, 1, "expected 1 concept for Michael Hunter")
+	assert.Equal(t, "http://api.ft.com/things/9332270e-f959-3f55-9153-d30acd0d0a51", michaelHunterConcepts[0].ID)
+
+	// check for `filter`
+	req, _ = http.NewRequest("POST", "http://dummy_host/concepts", strings.NewReader(`
 		{
-			"exactMatchTerms":[
+			"bestMatchTerms":[
 				"Platt Eric",
 				"Michael Hunter",
 				"Samson Adam"
-			]
+			],
+			"conceptTypes": ["http://www.ft.com/ontology/person/Person"],
+			"filter": "authors"
 		}`))
 	w = httptest.NewRecorder()
 	conceptFinder.FindConcept(w, req)
@@ -437,16 +521,22 @@ func TestEsExactMatchImpl(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	err = json.Unmarshal(w.Body.Bytes(), &searchResults)
 	assert.Equal(t, nil, err)
-	assert.Len(t, searchResults.Results, 3)
-	counter = 0
-	for _, res := range searchResults.Results {
-		if res.PrefLabel == "Eric Platt" ||
-			res.PrefLabel == "Michael Hunter" ||
-			res.PrefLabel == "Adam Samson" {
-			counter++
-		}
-	}
-	assert.Equal(t, 3, counter)
+	assert.Len(t, searchResults, 3)
+
+	ericPlattConcepts, ok = searchResults["Platt Eric"]
+	assert.True(t, ok, "expected results for Platt Eric")
+	assert.Len(t, ericPlattConcepts, 1, "expected 1 concept for Platt Eric")
+	assert.Equal(t, "http://api.ft.com/things/64302452-e369-4ddb-88fa-9adc5124a38c", ericPlattConcepts[0].ID)
+
+	adamSamsonConcepts, ok = searchResults["Samson Adam"]
+	assert.True(t, ok, "expected results for Adam Samson")
+	assert.Len(t, adamSamsonConcepts, 1, "expected 1 concept for Adam Samson")
+	assert.Equal(t, "http://api.ft.com/things/f758ef56-c40a-3162-91aa-3e8a3aabc494", adamSamsonConcepts[0].ID)
+
+	michaelHunterConcepts, ok = searchResults["Michael Hunter"]
+	assert.True(t, ok, "expected results for Michael Hunter")
+	assert.Len(t, michaelHunterConcepts, 1, "expected 1 concept for Michael Hunter")
+	assert.Equal(t, "http://api.ft.com/things/9332270e-f959-3f55-9153-d30acd0d0a51", michaelHunterConcepts[0].ID)
 }
 
 func getElasticSearchTestURL(t *testing.T) string {
@@ -480,6 +570,10 @@ func (tc failClient) query(indexName string, query elastic.Query, resultLimit in
 	return &elastic.SearchResult{}, errors.New("Test ES failure")
 }
 
+func (tc failClient) multiSearchQuery(indexName string, searchRequests ...*elastic.SearchRequest) (*elastic.MultiSearchResult, error) {
+	return &elastic.MultiSearchResult{}, errors.New("Test ES failure")
+}
+
 func (tc failClient) getClusterHealth() (*elastic.ClusterHealthResponse, error) {
 	return &elastic.ClusterHealthResponse{}, errors.New("Test ES failure")
 }
@@ -490,6 +584,15 @@ type mockClient struct {
 
 func (mc mockClient) query(indexName string, query elastic.Query, resultLimit int) (*elastic.SearchResult, error) {
 	var searchResult elastic.SearchResult
+	err := json.Unmarshal([]byte(mc.queryResponse), &searchResult)
+	if err != nil {
+		log.Printf("%v \n", err.Error())
+	}
+	return &searchResult, nil
+}
+
+func (mc mockClient) multiSearchQuery(indexName string, searchRequests ...*elastic.SearchRequest) (*elastic.MultiSearchResult, error) {
+	var searchResult elastic.MultiSearchResult
 	err := json.Unmarshal([]byte(mc.queryResponse), &searchResult)
 	if err != nil {
 		log.Printf("%v \n", err.Error())
@@ -700,8 +803,8 @@ var filterScoreTestingData = map[string]string{
 }`,
 }
 
-var exactMatchIndexName = "exact_match_index"
-var exactMatchTestingData = map[string]string{
+var bestMatchIndexName = "exact_match_index"
+var bestMatchTestingData = map[string]string{
 	"f758ef56-c40a-3162-91aa-3e8a3aabc494": `{
 		"id": "http://api.ft.com/things/f758ef56-c40a-3162-91aa-3e8a3aabc494",
 		"apiUrl": "http://api.ft.com/people/f758ef56-c40a-3162-91aa-3e8a3aabc494",
@@ -803,123 +906,312 @@ var exactMatchTestingData = map[string]string{
 		],
 		"isFTAuthor": "false"}`,
 }
-var validResponseExactMatch = `{
-    "took": 20,
-    "timed_out": false,
-    "_shards": {
-        "total": 5,
-        "successful": 5,
-        "failed": 0
-    },
-    "hits": {
-        "total": 4,
-        "max_score": 28.629284,
-        "hits": [
-            {
-                "_index": "concepts-0.2.2",
-                "_type": "people",
-                "_id": "f758ef56-c40a-3162-91aa-3e8a3aabc494",
-                "_score": 28.629284,
-                "_source": {
-                    "id": "http://api.ft.com/things/f758ef56-c40a-3162-91aa-3e8a3aabc494",
-                    "apiUrl": "http://api.ft.com/people/f758ef56-c40a-3162-91aa-3e8a3aabc494",
-                    "prefLabel": "Adam Samson",
-                    "types": [
-                        "http://www.ft.com/ontology/core/Thing",
-                        "http://www.ft.com/ontology/concept/Concept",
-                        "http://www.ft.com/ontology/person/Person"
-                    ],
-                    "authorities": [
-                        "TME"
-                    ],
-                    "directType": "http://www.ft.com/ontology/person/Person",
-                    "aliases": [
-                        "Adam Samson"
-                    ],
-                    "lastModified": "2018-06-08T14:34:22Z",
-                    "publishReference": "job_dNZnTv32iM",
-                    "isFTAuthor": "true"
-                }
+var validResponseBestMatch = `{
+    "responses": [
+        {
+            "took": 46,
+            "timed_out": false,
+            "_shards": {
+                "total": 5,
+                "successful": 5,
+                "failed": 0
             },
-            {
-                "_index": "concepts-0.2.2",
-                "_type": "people",
-                "_id": "64302452-e369-4ddb-88fa-9adc5124a38c",
-                "_score": 28.060131,
-                "_source": {
-                    "id": "http://api.ft.com/things/64302452-e369-4ddb-88fa-9adc5124a38c",
-                    "apiUrl": "http://api.ft.com/people/64302452-e369-4ddb-88fa-9adc5124a38c",
-                    "prefLabel": "Eric Platt",
-                    "types": [
-                        "http://www.ft.com/ontology/core/Thing",
-                        "http://www.ft.com/ontology/concept/Concept",
-                        "http://www.ft.com/ontology/person/Person"
-                    ],
-                    "authorities": [
-                        "TME",
-                        "Smartlogic"
-                    ],
-                    "directType": "http://www.ft.com/ontology/person/Person",
-                    "aliases": [
-                        "Eric Platt"
-                    ],
-                    "lastModified": "2018-06-08T14:34:29Z",
-                    "publishReference": "tid_fQ3qCMiEvC",
-                    "isFTAuthor": "true"
-                }
+            "hits": {
+                "total": 1,
+                "max_score": 16.835419,
+                "hits": [
+                    {
+                        "_index": "concepts-0.2.2",
+                        "_type": "people",
+                        "_id": "f758ef56-c40a-3162-91aa-3e8a3aabc494",
+                        "_score": 16.835419,
+                        "_source": {
+                            "id": "http://api.ft.com/things/f758ef56-c40a-3162-91aa-3e8a3aabc494",
+                            "apiUrl": "http://api.ft.com/people/f758ef56-c40a-3162-91aa-3e8a3aabc494",
+                            "prefLabel": "Adam Samson",
+                            "types": [
+                                "http://www.ft.com/ontology/core/Thing",
+                                "http://www.ft.com/ontology/concept/Concept",
+                                "http://www.ft.com/ontology/person/Person"
+                            ],
+                            "authorities": [
+                                "TME"
+                            ],
+                            "directType": "http://www.ft.com/ontology/person/Person",
+                            "aliases": [
+                                "Adam Samson"
+                            ],
+                            "lastModified": "2018-06-08T14:34:22Z",
+                            "publishReference": "job_dNZnTv32iM",
+                            "isFTAuthor": "true"
+                        }
+                    }
+                ]
             },
-            {
-                "_index": "concepts-0.2.2",
-                "_type": "people",
-                "_id": "9332270e-f959-3f55-9153-d30acd0d0a51",
-                "_score": 25.467949,
-                "_source": {
-                    "id": "http://api.ft.com/things/9332270e-f959-3f55-9153-d30acd0d0a51",
-                    "apiUrl": "http://api.ft.com/people/9332270e-f959-3f55-9153-d30acd0d0a51",
-                    "prefLabel": "Michael Hunter",
-                    "types": [
-                        "http://www.ft.com/ontology/core/Thing",
-                        "http://www.ft.com/ontology/concept/Concept",
-                        "http://www.ft.com/ontology/person/Person"
-                    ],
-                    "authorities": [
-                        "TME"
-                    ],
-                    "directType": "http://www.ft.com/ontology/person/Person",
-                    "aliases": [
-                        "Michael Hunter"
-                    ],
-                    "lastModified": "2018-06-08T14:34:27Z",
-                    "publishReference": "job_dNZnTv32iM",
-                    "isFTAuthor": "true"
-                }
+            "status": 200
+        },
+        {
+            "took": 41,
+            "timed_out": false,
+            "_shards": {
+                "total": 5,
+                "successful": 5,
+                "failed": 0
             },
-            {
-                "_index": "concepts-0.2.2",
-                "_type": "people",
-                "_id": "40281396-8369-4699-ae48-1ccc0c931a72",
-                "_score": 15.63516,
-                "_source": {
-                    "id": "http://api.ft.com/things/40281396-8369-4699-ae48-1ccc0c931a72",
-                    "apiUrl": "http://api.ft.com/people/40281396-8369-4699-ae48-1ccc0c931a72",
-                    "prefLabel": "Eric Platt",
-                    "types": [
-                        "http://www.ft.com/ontology/core/Thing",
-                        "http://www.ft.com/ontology/concept/Concept",
-                        "http://www.ft.com/ontology/person/Person"
-                    ],
-                    "authorities": [
-                        "TME",
-                        "Smartlogic"
-                    ],
-                    "directType": "http://www.ft.com/ontology/person/Person",
-                    "aliases": [
-                        "Eric Platt"
-                    ],
-					"isFTAuthor": "false",
-					"isDeprecated": true
-                }
-            }
-        ]
-    }
+            "hits": {
+                "total": 2,
+                "max_score": 16.62907,
+                "hits": [
+                    {
+                        "_index": "concepts-0.2.2",
+                        "_type": "people",
+                        "_id": "40281396-8369-4699-ae48-1ccc0c931a72",
+                        "_score": 16.62907,
+                        "_source": {
+                            "id": "http://api.ft.com/things/40281396-8369-4699-ae48-1ccc0c931a72",
+                            "apiUrl": "http://api.ft.com/people/40281396-8369-4699-ae48-1ccc0c931a72",
+                            "prefLabel": "Eric Platt",
+                            "types": [
+                                "http://www.ft.com/ontology/core/Thing",
+                                "http://www.ft.com/ontology/concept/Concept",
+                                "http://www.ft.com/ontology/person/Person"
+                            ],
+                            "authorities": [
+                                "TME",
+                                "Smartlogic"
+                            ],
+                            "directType": "http://www.ft.com/ontology/person/Person",
+                            "aliases": [
+                                "Eric Platt"
+                            ],
+                            "isFTAuthor": "false"
+                        }
+                    },
+                    {
+                        "_index": "concepts-0.2.2",
+                        "_type": "people",
+                        "_id": "64302452-e369-4ddb-88fa-9adc5124a38c",
+                        "_score": 16.264492,
+                        "_source": {
+                            "id": "http://api.ft.com/things/64302452-e369-4ddb-88fa-9adc5124a38c",
+                            "apiUrl": "http://api.ft.com/people/64302452-e369-4ddb-88fa-9adc5124a38c",
+                            "prefLabel": "Eric Platt",
+                            "types": [
+                                "http://www.ft.com/ontology/core/Thing",
+                                "http://www.ft.com/ontology/concept/Concept",
+                                "http://www.ft.com/ontology/person/Person"
+                            ],
+                            "authorities": [
+                                "TME",
+                                "Smartlogic"
+                            ],
+                            "directType": "http://www.ft.com/ontology/person/Person",
+                            "aliases": [
+                                "Eric Platt"
+                            ],
+                            "lastModified": "2018-06-08T14:34:29Z",
+                            "publishReference": "tid_fQ3qCMiEvC",
+                            "isFTAuthor": "true"
+                        }
+                    }
+                ]
+            },
+            "status": 200
+        },
+        {
+            "took": 8,
+            "timed_out": false,
+            "_shards": {
+                "total": 5,
+                "successful": 5,
+                "failed": 0
+            },
+            "hits": {
+                "total": 1,
+                "max_score": 12.8185625,
+                "hits": [
+                    {
+                        "_index": "concepts-0.2.2",
+                        "_type": "people",
+                        "_id": "9332270e-f959-3f55-9153-d30acd0d0a51",
+                        "_score": 12.8185625,
+                        "_source": {
+                            "id": "http://api.ft.com/things/9332270e-f959-3f55-9153-d30acd0d0a51",
+                            "apiUrl": "http://api.ft.com/people/9332270e-f959-3f55-9153-d30acd0d0a51",
+                            "prefLabel": "Michael Hunter",
+                            "types": [
+                                "http://www.ft.com/ontology/core/Thing",
+                                "http://www.ft.com/ontology/concept/Concept",
+                                "http://www.ft.com/ontology/person/Person"
+                            ],
+                            "authorities": [
+                                "TME"
+                            ],
+                            "directType": "http://www.ft.com/ontology/person/Person",
+                            "aliases": [
+                                "Michael Hunter"
+                            ],
+                            "lastModified": "2018-06-08T14:34:27Z",
+                            "publishReference": "job_dNZnTv32iM",
+                            "isFTAuthor": "true"
+                        }
+                    }
+                ]
+            },
+            "status": 200
+        }
+    ]
+}`
+
+var validResponseBestMatchPartialResults = `{
+    "responses": [
+        {
+            "took": 46,
+            "timed_out": false,
+            "_shards": {
+                "total": 5,
+                "successful": 5,
+                "failed": 0
+            },
+            "hits": {
+                "total": 1,
+                "max_score": 16.835419,
+                "hits": [
+                    {
+                        "_index": "concepts-0.2.2",
+                        "_type": "people",
+                        "_id": "f758ef56-c40a-3162-91aa-3e8a3aabc494",
+                        "_score": 16.835419,
+                        "_source": {
+                            "id": "http://api.ft.com/things/f758ef56-c40a-3162-91aa-3e8a3aabc494",
+                            "apiUrl": "http://api.ft.com/people/f758ef56-c40a-3162-91aa-3e8a3aabc494",
+                            "prefLabel": "Adam Samson",
+                            "types": [
+                                "http://www.ft.com/ontology/core/Thing",
+                                "http://www.ft.com/ontology/concept/Concept",
+                                "http://www.ft.com/ontology/person/Person"
+                            ],
+                            "authorities": [
+                                "TME"
+                            ],
+                            "directType": "http://www.ft.com/ontology/person/Person",
+                            "aliases": [
+                                "Adam Samson"
+                            ],
+                            "lastModified": "2018-06-08T14:34:22Z",
+                            "publishReference": "job_dNZnTv32iM",
+                            "isFTAuthor": "true"
+                        }
+                    }
+                ]
+            },
+            "status": 200
+        },
+        {
+            "took": 41,
+            "timed_out": false,
+            "_shards": {
+                "total": 5,
+                "successful": 5,
+                "failed": 0
+            },
+            "hits": {
+                "total": 0,
+                "max_score": null,
+                "hits": []
+            },
+            "status": 200
+        },
+        {
+            "took": 8,
+            "timed_out": false,
+            "_shards": {
+                "total": 5,
+                "successful": 5,
+                "failed": 0
+            },
+            "hits": {
+                "total": 1,
+                "max_score": 12.8185625,
+                "hits": [
+                    {
+                        "_index": "concepts-0.2.2",
+                        "_type": "people",
+                        "_id": "9332270e-f959-3f55-9153-d30acd0d0a51",
+                        "_score": 12.8185625,
+                        "_source": {
+                            "id": "http://api.ft.com/things/9332270e-f959-3f55-9153-d30acd0d0a51",
+                            "apiUrl": "http://api.ft.com/people/9332270e-f959-3f55-9153-d30acd0d0a51",
+                            "prefLabel": "Michael Hunter",
+                            "types": [
+                                "http://www.ft.com/ontology/core/Thing",
+                                "http://www.ft.com/ontology/concept/Concept",
+                                "http://www.ft.com/ontology/person/Person"
+                            ],
+                            "authorities": [
+                                "TME"
+                            ],
+                            "directType": "http://www.ft.com/ontology/person/Person",
+                            "aliases": [
+                                "Michael Hunter"
+                            ],
+                            "lastModified": "2018-06-08T14:34:27Z",
+                            "publishReference": "job_dNZnTv32iM",
+                            "isFTAuthor": "true"
+                        }
+                    }
+                ]
+            },
+            "status": 200
+        }
+    ]
+}`
+var validResponseBestMatchNoResults = `{
+    "responses": [
+        {
+            "took": 46,
+            "timed_out": false,
+            "_shards": {
+                "total": 5,
+                "successful": 5,
+                "failed": 0
+            },
+            "hits": {
+                "total": 0,
+                "max_score": null,
+                "hits": []
+            },
+            "status": 200
+        },
+        {
+            "took": 41,
+            "timed_out": false,
+            "_shards": {
+                "total": 5,
+                "successful": 5,
+                "failed": 0
+            },
+            "hits": {
+                "total": 0,
+                "max_score": null,
+                "hits": []
+            },
+            "status": 200
+        },
+        {
+            "took": 8,
+            "timed_out": false,
+            "_shards": {
+                "total": 5,
+                "successful": 5,
+                "failed": 0
+            },
+            "hits": {
+                "total": 0,
+                "max_score": null,
+                "hits": []
+            },
+            "status": 200
+        }
+    ]
 }`

--- a/service_test.go
+++ b/service_test.go
@@ -152,7 +152,7 @@ func TestConceptFinder(t *testing.T) {
 	}
 }
 
-func TestConceptFinderForPrefLabel(t *testing.T) {
+func TestConceptFinderForExactMatch(t *testing.T) {
 
 	testCases := []struct {
 		testName      string
@@ -168,7 +168,7 @@ func TestConceptFinderForPrefLabel(t *testing.T) {
 			client:        mockClient{},
 			returnCode:    http.StatusBadRequest,
 			requestURL:    defaultRequestURL,
-			requestBody:   `{"term":"Foobar", "prefLabels":["testPrefLabel"]}`,
+			requestBody:   `{"term":"Foobar", "exactMatchTerms":["testTerm"]}`,
 			expectedScore: nil,
 		},
 		{
@@ -176,7 +176,7 @@ func TestConceptFinderForPrefLabel(t *testing.T) {
 			client:        mockClient{},
 			returnCode:    http.StatusBadRequest,
 			requestURL:    defaultRequestURL + "?boost=wrong_boost",
-			requestBody:   `{"prefLabels":["testPrefLabel"]}`,
+			requestBody:   `{"exactMatchTerms":["testTerm"]}`,
 			expectedScore: nil,
 		},
 		{
@@ -184,7 +184,7 @@ func TestConceptFinderForPrefLabel(t *testing.T) {
 			client:        mockClient{},
 			returnCode:    http.StatusBadRequest,
 			requestURL:    defaultRequestURL + "?boost=authors&type=http://www.ft.com/ontology/organisation/Organisation",
-			requestBody:   `{"prefLabels":["testPrefLabel"]}`,
+			requestBody:   `{"exactMatchTerms":["testTerm"]}`,
 			expectedScore: nil,
 		},
 		{
@@ -192,17 +192,17 @@ func TestConceptFinderForPrefLabel(t *testing.T) {
 			client:        mockClient{},
 			returnCode:    http.StatusBadRequest,
 			requestURL:    defaultRequestURL + "?boost=authors",
-			requestBody:   `{"prefLabels":["testPrefLabel"]}`,
+			requestBody:   `{"exactMatchTerms":["testTerm"]}`,
 			expectedScore: nil,
 		},
 		{
 			testName: "OkPeopleType",
 			client: mockClient{
-				queryResponse: validResponseExactPrefLabel,
+				queryResponse: validResponseExactMatch,
 			},
 			returnCode:    http.StatusOK,
 			requestURL:    defaultRequestURL + "?type=http://www.ft.com/ontology/person/Person",
-			requestBody:   `{"prefLabels":["Eric Platt","Michael Hunter","Adam Samson"]}`,
+			requestBody:   `{"exactMatchTerms":["Eric Platt","Michael Hunter","Adam Samson"]}`,
 			expectedUUIDs: []string{"f758ef56-c40a-3162-91aa-3e8a3aabc494", "64302452-e369-4ddb-88fa-9adc5124a38c", "9332270e-f959-3f55-9153-d30acd0d0a51", "40281396-8369-4699-ae48-1ccc0c931a72"},
 			expectedScore: []float64{28.629284, 28.060131, 25.467949, 15.63516},
 		},
@@ -313,7 +313,7 @@ func TestEsExactMatchImpl(t *testing.T) {
 	// prepare request and trigger this
 	req, _ := http.NewRequest("POST", "http://dummy_host/concepts?type=http://www.ft.com/ontology/person/Person", strings.NewReader(`
 		{
-			"prefLabels":[
+			"exactMatchTerms":[
 				"Platt Eric",
 				"Michael Hunter",
 				"Samson Adam"
@@ -695,7 +695,7 @@ var exactMatchTestingData = map[string]string{
 		],
 		"isFTAuthor": "false"}`,
 }
-var validResponseExactPrefLabel = `{
+var validResponseExactMatch = `{
     "took": 20,
     "timed_out": false,
     "_shards": {

--- a/util/data.go
+++ b/util/data.go
@@ -1,0 +1,99 @@
+package util
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	esTypeMapping = map[string]string{
+		"http://www.ft.com/ontology/Genre":                     "genres",
+		"http://www.ft.com/ontology/product/Brand":             "brands",
+		"http://www.ft.com/ontology/person/Person":             "people",
+		"http://www.ft.com/ontology/organisation/Organisation": "organisations",
+		"http://www.ft.com/ontology/Location":                  "locations",
+		"http://www.ft.com/ontology/Topic":                     "topics",
+	}
+
+	ErrInvalidConceptTypeFormat              = "invalid concept type %v"
+	ErrNoElasticClient                       = errors.New("no ElasticSearch client available")
+	ErrNoConceptTypeParameter                = NewInputError("no concept type specified")
+	ErrNotSupportedCombinationOfConceptTypes = NewInputError("the combination of concept types is not supported")
+	ErrInvalidBoostTypeParameter             = NewInputError("invalid boost type")
+)
+
+func FirstError(errors ...error) error {
+	for _, err := range errors {
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ToTerms(types []string) []interface{} {
+	i := make([]interface{}, 0)
+	for _, v := range types {
+		i = append(i, v)
+	}
+	return i
+}
+
+func EsType(ftType string) string {
+	return esTypeMapping[ftType]
+}
+
+func FtType(esType string) string {
+	for k, v := range esTypeMapping {
+		if v == esType {
+			return k
+		}
+	}
+
+	return ""
+}
+
+func ValidateForAuthorsSearch(conceptTypes []string, boostType string) error {
+	if len(conceptTypes) == 0 {
+		return ErrNoConceptTypeParameter
+	}
+	if len(conceptTypes) > 1 {
+		return ErrNotSupportedCombinationOfConceptTypes
+	}
+	if EsType(conceptTypes[0]) != "people" {
+		return NewInputErrorf(ErrInvalidConceptTypeFormat, conceptTypes[0])
+	}
+	if boostType != "authors" {
+		return ErrInvalidBoostTypeParameter
+	}
+	return nil
+}
+
+func ValidateAndConvertToEsTypes(conceptTypes []string) ([]string, error) {
+	esTypes := make([]string, len(conceptTypes))
+	for _, t := range conceptTypes {
+		esT := EsType(t)
+		if esT == "" {
+			return esTypes, NewInputErrorf(ErrInvalidConceptTypeFormat, t)
+		}
+		esTypes = append(esTypes, esT)
+	}
+	return esTypes, nil
+}
+
+type InputError struct {
+	msg string
+}
+
+func (e InputError) Error() string {
+	return e.msg
+}
+
+func NewInputError(msg string) InputError {
+	return InputError{msg}
+}
+
+func NewInputErrorf(format string, args ...interface{}) InputError {
+	return InputError{fmt.Sprintf(format, args...)}
+}

--- a/util/data_test.go
+++ b/util/data_test.go
@@ -1,0 +1,45 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEsType(t *testing.T) {
+	assert.Equal(t, "genres", EsType("http://www.ft.com/ontology/Genre"), "known type conversion")
+	assert.Equal(t, "", EsType("http://www.ft.com/ontology/Foo"), "unknown type conversion")
+}
+
+func TestFtType(t *testing.T) {
+	assert.Equal(t, "http://www.ft.com/ontology/Genre", FtType("genres"), "known type conversion")
+	assert.Equal(t, "", FtType("tardigrades"), "unknown type conversion")
+}
+
+func TestValidateAuthors(t *testing.T) {
+	// validate no types given
+	assert.Equal(t, ValidateForAuthorsSearch([]string{}, "authors").Error(), ErrNoConceptTypeParameter.Error())
+
+	// validate too many types given
+	assert.Equal(t, ValidateForAuthorsSearch([]string{"http://www.ft.com/ontology/person/Person", "http://www.ft.com/ontology/Genre"}, "authors").Error(), ErrNotSupportedCombinationOfConceptTypes.Error())
+
+	// wrong type
+	assert.Contains(t, ValidateForAuthorsSearch([]string{"http://www.ft.com/ontology/Genre"}, "authors").Error(), "http://www.ft.com/ontology/Genre")
+
+	// good type and wrong boost name
+	assert.Equal(t, ValidateForAuthorsSearch([]string{"http://www.ft.com/ontology/person/Person"}, "wrong_boost").Error(), ErrInvalidBoostTypeParameter.Error())
+
+	// happy path
+	assert.Nil(t, ValidateForAuthorsSearch([]string{"http://www.ft.com/ontology/person/Person"}, "authors"))
+}
+
+func TestValidateEsTypes(t *testing.T) {
+	res, err := ValidateAndConvertToEsTypes([]string{"http://www.ft.com/ontology/Foo", "http://www.ft.com/ontology/person/Person"})
+	assert.Contains(t, err.Error(), "http://www.ft.com/ontology/Foo")
+
+	res, err = ValidateAndConvertToEsTypes([]string{"http://www.ft.com/ontology/person/Person"})
+	assert.NoError(t, err)
+	assert.Len(t, res, 2)
+	assert.Equal(t, "", res[0])
+	assert.Equal(t, "people", res[1])
+}

--- a/util/http.go
+++ b/util/http.go
@@ -1,0 +1,50 @@
+package util
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+func GetSingleValueQueryParameter(req *http.Request, param string, allowed ...string) (string, bool, error) {
+	values, found := GetMultipleValueQueryParameter(req, param)
+	if len(values) > 1 {
+		return "", found, fmt.Errorf("specified multiple %v query parameters in the URL", param)
+	}
+	if len(values) < 1 {
+		return "", found, nil
+	}
+
+	v := values[0]
+	if len(allowed) > 0 {
+		for _, a := range allowed {
+			if v == a {
+				return v, found, nil
+			}
+		}
+
+		return "", found, fmt.Errorf("'%s' is not a valid value for parameter '%s'", v, param)
+	}
+
+	return v, found, nil
+}
+
+func GetBoolQueryParameter(req *http.Request, param string, defaultVal bool) (bool, bool, error) {
+	val, found, err := GetSingleValueQueryParameter(req, param)
+	if !found || err != nil {
+		return defaultVal, found, err
+	}
+
+	boolVal, err := strconv.ParseBool(val)
+	if err != nil {
+		return defaultVal, false, err
+	}
+
+	return boolVal, true, nil
+}
+
+func GetMultipleValueQueryParameter(req *http.Request, param string) ([]string, bool) {
+	query := req.URL.Query()
+	values, found := query[param]
+	return values, found
+}

--- a/util/http_test.go
+++ b/util/http_test.go
@@ -1,0 +1,68 @@
+package util
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var httpTestBasePath = "http://localhost/my_path"
+
+func TestGetSingleQueryValueNoParam(t *testing.T) {
+	req, _ := http.NewRequest("GET", httpTestBasePath, nil)
+	value, found, err := GetSingleValueQueryParameter(req, "test-param")
+	assert.Empty(t, value)
+	assert.False(t, found)
+	assert.NoError(t, err)
+}
+
+func TestGetSingleQueryValueMultiParams(t *testing.T) {
+	req, _ := http.NewRequest("GET", httpTestBasePath+"?test-param=a&test-param=b", nil)
+	value, found, err := GetSingleValueQueryParameter(req, "test-param")
+	assert.Empty(t, value)
+	assert.True(t, found)
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "specified multiple test-param query parameters in the URL")
+}
+
+func TestGetSingleQueryValueNoAllowedValues(t *testing.T) {
+	req, _ := http.NewRequest("GET", httpTestBasePath+"?test-param=a", nil)
+	value, found, err := GetSingleValueQueryParameter(req, "test-param", "x")
+	assert.Empty(t, value)
+	assert.True(t, found)
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "'a' is not a valid value for parameter 'test-param'")
+}
+
+func TestGetSingleQueryValueAllowedValue(t *testing.T) {
+	req, _ := http.NewRequest("GET", httpTestBasePath+"?test-param=a", nil)
+	value, found, err := GetSingleValueQueryParameter(req, "test-param", "x", "a")
+	assert.Equal(t, "a", value)
+	assert.True(t, found)
+	assert.NoError(t, err)
+}
+
+func TestGetBoolValueMultiParams(t *testing.T) {
+	req, _ := http.NewRequest("GET", httpTestBasePath+"?test-param=true&test-param=false", nil)
+	value, found, err := GetBoolQueryParameter(req, "test-param", false)
+	assert.False(t, value)
+	assert.True(t, found)
+	assert.Equal(t, "specified multiple test-param query parameters in the URL", err.Error())
+}
+
+func TestGetBoolValueNotBoolValueGiven(t *testing.T) {
+	req, _ := http.NewRequest("GET", httpTestBasePath+"?test-param=a", nil)
+	value, found, err := GetBoolQueryParameter(req, "test-param", false)
+	assert.False(t, value)
+	assert.False(t, found)
+	assert.Equal(t, "strconv.ParseBool: parsing \"a\": invalid syntax", err.Error())
+}
+
+func TestGetBoolValueOkValue(t *testing.T) {
+	req, _ := http.NewRequest("GET", httpTestBasePath+"?test-param=true", nil)
+	value, found, err := GetBoolQueryParameter(req, "test-param", false)
+	assert.True(t, value)
+	assert.True(t, found)
+	assert.NoError(t, err)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -19,9 +19,9 @@
 			"versionExact": "0.4.0"
 		},
 		{
-			"checksumSHA1": "zUpINnstJChGK0LAtkt7jBc3RY0=",
+			"checksumSHA1": "dqF1g4reeLPNN10qTXgDJj3fHm4=",
 			"path": "github.com/Financial-Times/http-handlers-go/httphandlers",
-			"revision": "bb69c454da9050fe1c4b92fe1345a01583ee70be",
+			"revision": "229ac16f1d9ec9bca485d2dafb9ec14dc7e9ba24",
 			"revisionTime": "2016-08-03T10:40:03Z"
 		},
 		{
@@ -50,7 +50,7 @@
 		},
 		{
 			"checksumSHA1": "0Tugz8gj9KqqVj6JLkXUA7BXas4=",
-			"path": "github.com/Sirupsen/logrus",
+			"path": "github.com/sirupsen/logrus",
 			"revision": "0208149b40d863d2c1a2f8fe5753096a9cf2cc8b",
 			"revisionTime": "2017-02-27T12:44:09Z"
 		},
@@ -175,7 +175,7 @@
 			"revisionTime": "2017-02-23T22:05:28Z"
 		},
 		{
-			"checksumSHA1": "gcAbdDsQhr/7HRKu9oiRwDgn6bc=",
+			"checksumSHA1": "w9fcXTjDpokET5bDHQsPCLTsGw8=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "b8f5ef32195cae6470b728e8ca677f0dbed1a004",
 			"revisionTime": "2017-12-08T14:03:20Z"


### PR DESCRIPTION
Some things moved for being accessible by the new implementation.

Description:

We need the possiblity to fetch concepts more accurately. For doing this, a list of phrases are passed to the concept-search-api, and this tries to return only the documents that contains all tokens into their aliases.
For example, if I want to get a location (ie: New York), I don't need a list with documents containing in `aliases` one of the terms (New or York) sorted based on score, but I want all concepts that contains both terms.

For making this to work, I decided to integrate this in the already existing endpoint (`/concept/search`) and added one more body field (`exactMatchTerms`), which is a list of phrases. This is tokenized by space and the query is generated out of these resulted tokens.

Also, several query params added:
* `include_field` ([]string) - accepts only “authors” right now. If the “authors” value is sent, the concept's field “isFTAuthor” will be included in the results.
* `type` ([]string) - list of types for filtering
* `boost` (string) - the type of boost that should be applied for the resulted documents
* `filter` (string) - contains same values as `boost` but the generated condition is not used as a `should` query but as `must` query


Eg:
```
POST /concept/search?type=http://www.ft.com/ontology/person/Person&filter=authors
{
	"exactMatchTerms":[
		"Eric Platt",
		"Michael Hunter",
		"Adam Samson"
	]
}
```
will return a list of the following documents
```
{
    "results": [
        {
            "id": "http://api.ft.com/things/f758ef56-c40a-3162-91aa-3e8a3aabc494",
            "apiUrl": "http://api.ft.com/people/f758ef56-c40a-3162-91aa-3e8a3aabc494",
            "prefLabel": "Adam Samson",
            "types": [
                "http://www.ft.com/ontology/core/Thing",
                "http://www.ft.com/ontology/concept/Concept",
                "http://www.ft.com/ontology/person/Person"
            ],
            "directType": "http://www.ft.com/ontology/person/Person",
            "aliases": [
                "Adam Samson"
            ]
        },
        {
            "id": "http://api.ft.com/things/64302452-e369-4ddb-88fa-9adc5124a38c",
            "apiUrl": "http://api.ft.com/people/64302452-e369-4ddb-88fa-9adc5124a38c",
            "prefLabel": "Eric Platt",
            "types": [
                "http://www.ft.com/ontology/core/Thing",
                "http://www.ft.com/ontology/concept/Concept",
                "http://www.ft.com/ontology/person/Person"
            ],
            "directType": "http://www.ft.com/ontology/person/Person",
            "aliases": [
                "Eric Platt"
            ]
        },
        {
            "id": "http://api.ft.com/things/9332270e-f959-3f55-9153-d30acd0d0a51",
            "apiUrl": "http://api.ft.com/people/9332270e-f959-3f55-9153-d30acd0d0a51",
            "prefLabel": "Michael Hunter",
            "types": [
                "http://www.ft.com/ontology/core/Thing",
                "http://www.ft.com/ontology/concept/Concept",
                "http://www.ft.com/ontology/person/Person"
            ],
            "directType": "http://www.ft.com/ontology/person/Person",
            "aliases": [
                "Michael Hunter"
            ]
        }
    ]
}
```
