### PR TITLE
Factset Public Companies in Concept Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ To include the score you need to add the query parameter `include_score` with th
 curl -XPOST {concept-search-api-url}/concept/search?include_score=true -d '{"term":"FOO"}'
 ```
 
+By default the endpoint only retrieves results with TME or Smartlogic authority. To extend the search domain you need to add the query parameter `searchAllAuthorities` with the value `true`. This will return TME, Smartlogic, Factset or any other and no authority results.
+```
+curl -XPOST {concept-search-api-url}/concept/search?searchAllAuthorities=true -d '{"term":"FOO"}'
+```
+
 By default the endpoint returns only *non-deprecated* concepts. In order to get the deprecated concepts too, you should provide query parameter `include_deprecated` with the value `true`.
 ```
 curl -XPOST {concept-search-api-url}/concept/search?include_deprecated=true -d '{"term":"FOO"}'
@@ -120,6 +125,26 @@ This endpoint is used for typeahead style queries for concepts. The request has 
 ```
 curl {concept-search-api-url}/concepts?type=http://www.ft.com/ontology/Genre
 ```
+
+Optional query parameters:
+- To activate the search mode, you can send the `mode` parameter with the value `search`, and `q` parameter with the value of the search query
+	```
+	curl {concept-search-api-url}/concepts?type=http://www.ft.com/ontology/organisation/Organisation&mode=search&q=FOO
+	```
+- `boost` parameter can be specified when activating  the search mode, but it is currently supported only for authors
+	
+	E.g. The following request will return results with `"isFTAuthor": true`
+	```
+	curl {concept-search-api-url}/concepts?type=http://www.ft.com/ontology/person/Person&mode=search&q=FOO&boost=authors
+	``` 
+- `searchAllAuthorities` parameter can be used to extend the search domain. This will return TME, Smartlogic, Factset or any other and no authority results	
+	```
+	curl {concept-search-api-url}/concepts?type=http://www.ft.com/ontology/Genre&searchAllAuthorities=true
+	```
+- `include_deprecated` paramenter can be used to include deprecated concepts in the search result
+	```
+	curl {concept-search-api-url}/concepts?type=http://www.ft.com/ontology/Genre&include_deprecated=true
+	```
 
 Please see the [Swagger YML](./_ft/api.yml) for more details.
 

--- a/_ft/api.yml
+++ b/_ft/api.yml
@@ -49,6 +49,7 @@ paths:
               - http://www.ft.com/ontology/Location
               - http://www.ft.com/ontology/Topic
               - http://www.ft.com/ontology/AlphavilleSeries
+              - http://www.ft.com/ontology/company/PublicCompany
           collectionFormat: multi
           required: true
           x-example:

--- a/helm/concept-search-api/templates/deployment.yaml
+++ b/helm/concept-search-api/templates/deployment.yaml
@@ -35,8 +35,10 @@ spec:
         env:
         - name: AUTH
           value: aws
-        - name: ELASTICSEARCH_INDEX
+        - name: ELASTICSEARCH_DEFAULT_INDEX
           value: concepts
+        - name: ELASTICSEARCH_EXTENDED_SEARCH_INDEX
+          value: all-conceps
         - name: RESULT_LIMIT
           value: "50"
         - name: AUTOCOMPLETE_LIMIT

--- a/helm/concept-search-api/templates/deployment.yaml
+++ b/helm/concept-search-api/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         - name: ELASTICSEARCH_DEFAULT_INDEX
           value: concepts
         - name: ELASTICSEARCH_EXTENDED_SEARCH_INDEX
-          value: all-conceps
+          value: all-concepts
         - name: RESULT_LIMIT
           value: "50"
         - name: AUTOCOMPLETE_LIMIT

--- a/main.go
+++ b/main.go
@@ -96,7 +96,7 @@ func main() {
 		logStartupConfig(port, esEndpoint, esAuth, esDefaultIndex, esExtendedSearchIndex, searchResultLimit)
 
 		search := service.NewEsConceptSearchService(*esDefaultIndex, *esExtendedSearchIndex, *searchResultLimit, *autoCompleteResultLimit, *authorsBoost)
-		conceptFinder := newConceptFinder(*esDefaultIndex, *searchResultLimit)
+		conceptFinder := newConceptFinder(*esDefaultIndex, *esExtendedSearchIndex, *searchResultLimit)
 		healthcheck := newEsHealthService()
 
 		if *esAuth == "aws" {

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func main() {
 	})
 	esExtendedSearchIndex := app.String(cli.StringOpt{
 		Name:   "elasticsearch-extended-index",
-		Value:  "concepts",
+		Value:  "all-concepts",
 		Desc:   "Elasticsearch extended index",
 		EnvVar: "ELASTICSEARCH_EXTENDED_SEARCH_INDEX",
 	})

--- a/main.go
+++ b/main.go
@@ -47,11 +47,17 @@ func main() {
 		Desc:   "Authentication method for ES cluster (aws or none)",
 		EnvVar: "AUTH",
 	})
-	esIndex := app.String(cli.StringOpt{
-		Name:   "elasticsearch-index",
+	esDefaultIndex := app.String(cli.StringOpt{
+		Name:   "elasticsearch-default-index",
 		Value:  "concepts",
-		Desc:   "Elasticsearch index",
-		EnvVar: "ELASTICSEARCH_INDEX",
+		Desc:   "Elasticsearch default index",
+		EnvVar: "ELASTICSEARCH_DEFAULT_INDEX",
+	})
+	esExtendedSearchIndex := app.String(cli.StringOpt{
+		Name:   "elasticsearch-extended-index",
+		Value:  "concepts",
+		Desc:   "Elasticsearch extended index",
+		EnvVar: "ELASTICSEARCH_EXTENDED_SEARCH_INDEX",
 	})
 	apiYml := app.String(cli.StringOpt{
 		Name:   "api-yml",
@@ -87,10 +93,10 @@ func main() {
 	log.SetLevel(log.InfoLevel)
 
 	app.Action = func() {
-		logStartupConfig(port, esEndpoint, esAuth, esIndex, searchResultLimit)
+		logStartupConfig(port, esEndpoint, esAuth, esDefaultIndex, esExtendedSearchIndex, searchResultLimit)
 
-		search := service.NewEsConceptSearchService(*esIndex, *searchResultLimit, *autoCompleteResultLimit, *authorsBoost)
-		conceptFinder := newConceptFinder(*esIndex, *searchResultLimit)
+		search := service.NewEsConceptSearchService(*esDefaultIndex, *esExtendedSearchIndex, *searchResultLimit, *autoCompleteResultLimit, *authorsBoost)
+		conceptFinder := newConceptFinder(*esDefaultIndex, *searchResultLimit)
 		healthcheck := newEsHealthService()
 
 		if *esAuth == "aws" {
@@ -111,12 +117,13 @@ func main() {
 	}
 }
 
-func logStartupConfig(port, esEndpoint, esAuth, esIndex *string, searchResultLimit *int) {
+func logStartupConfig(port, esEndpoint, esAuth, esDefaultIndex *string, esExtendedSearchIndex *string, searchResultLimit *int) {
 	log.Info("Concept Search API uses the following configurations:")
 	log.Infof("port: %v", *port)
 	log.Infof("elasticsearch-endpoint: %v", *esEndpoint)
 	log.Infof("elasticsearch-auth: %v", *esAuth)
-	log.Infof("elasticsearch-index: %v", *esIndex)
+	log.Infof("elasticsearch-index: %v", *esDefaultIndex)
+	log.Infof("elasticsearch-extended-index: %v", *esExtendedSearchIndex)
 	log.Infof("search-result-limit: %v", *searchResultLimit)
 }
 

--- a/resources/handler.go
+++ b/resources/handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Financial-Times/concept-search-api/service"
 	"gopkg.in/olivere/elastic.v5"
+	"strings"
 )
 
 type Handler struct {
@@ -119,7 +120,7 @@ func (h *Handler) findConceptsByType(conceptTypes []string, includeDeprecated bo
 	}
 
 	// at this point we go to the default alias
-	if conceptTypes[0] == "PublicCompany" {
+	if strings.Contains(conceptTypes[0], "PublicCompany") {
 		// different query for Public Companies
 		return h.service.FindAllConceptsByDirectType(conceptTypes[0], includeDeprecated)
 	}

--- a/resources/handler.go
+++ b/resources/handler.go
@@ -61,7 +61,7 @@ func (h *Handler) ConceptSearch(w http.ResponseWriter, req *http.Request) {
 				err = NewValidationError("invalid or missing parameters for concept search (require type)")
 			} else {
 				if mode == "search" {
-					concepts, err = h.searchConcepts(foundBoostType, boostType, foundQ, q, conceptTypes, includeDeprecated)
+					concepts, err = h.searchConcepts(foundBoostType, boostType, foundQ, q, conceptTypes, searchAllAuthorities, includeDeprecated)
 				}
 			}
 		} else {
@@ -100,13 +100,13 @@ func (h *Handler) ConceptSearch(w http.ResponseWriter, req *http.Request) {
 	json.NewEncoder(w).Encode(response)
 }
 
-func (h *Handler) searchConcepts(foundBoostType bool, boostType string, foundQ bool, q string, conceptTypes []string, includeDeprecated bool) ([]service.Concept, error) {
+func (h *Handler) searchConcepts(foundBoostType bool, boostType string, foundQ bool, q string, conceptTypes []string, searchAllAuthorities bool, includeDeprecated bool) ([]service.Concept, error) {
 	if !foundQ {
 		return nil, NewValidationError("invalid or missing parameters for concept search (require q)")
 	} else if foundBoostType {
-		return h.service.SearchConceptByTextAndTypesWithBoost(q, conceptTypes, boostType, includeDeprecated)
+		return h.service.SearchConceptByTextAndTypesWithBoost(q, conceptTypes, boostType, searchAllAuthorities, includeDeprecated)
 	}
-	return h.service.SearchConceptByTextAndTypes(q, conceptTypes, includeDeprecated)
+	return h.service.SearchConceptByTextAndTypes(q, conceptTypes, searchAllAuthorities, includeDeprecated)
 }
 
 func (h *Handler) findConceptsByType(conceptTypes []string, includeDeprecated bool, searchAllAuthorities bool) ([]service.Concept, error) {

--- a/resources/handler.go
+++ b/resources/handler.go
@@ -114,15 +114,8 @@ func (h *Handler) findConceptsByType(conceptTypes []string, includeDeprecated bo
 		return nil, NewValidationError("only a single type is supported by this kind of request")
 	}
 
-	if searchAllAuthorities {
-		// go to the new alias
-		return nil, nil
-	}
-
-	// at this point we go to the default alias
 	if strings.Contains(conceptTypes[0], "PublicCompany") {
-		// different query for Public Companies
-		return h.service.FindAllConceptsByDirectType(conceptTypes[0], includeDeprecated)
+		return h.service.FindAllConceptsByDirectType(conceptTypes[0], searchAllAuthorities, includeDeprecated)
 	}
 
 	return h.service.FindAllConceptsByType(conceptTypes[0], includeDeprecated)

--- a/resources/handler.go
+++ b/resources/handler.go
@@ -42,9 +42,9 @@ func (h *Handler) ConceptSearch(w http.ResponseWriter, req *http.Request) {
 	boostType, foundBoostType, boostTypeErr := util.GetSingleValueQueryParameter(req, "boost") // we currently only accept authors, so ignoring the actual boost value
 	ids, foundIds := util.GetMultipleValueQueryParameter(req, "ids")
 	includeDeprecated, _, includeDeprecatedErr := util.GetBoolQueryParameter(req, "include_deprecated", false)
-	searchAllAuthorities, _, allAuthoritiesErr := util.GetBoolQueryParameter(req, "searchAllAuthorities", false)
+	searchAllAuthorities, _, searchAllErr := util.GetBoolQueryParameter(req, "searchAllAuthorities", false)
 
-	err = util.FirstError(modeErr, qErr, boostTypeErr, includeDeprecatedErr, allAuthoritiesErr)
+	err = util.FirstError(modeErr, qErr, boostTypeErr, includeDeprecatedErr, searchAllErr)
 	if err != nil {
 		writeHTTPError(w, http.StatusBadRequest, err)
 		return
@@ -110,7 +110,11 @@ func (h *Handler) searchConcepts(foundBoostType bool, boostType string, foundQ b
 }
 
 func (h *Handler) findConceptsByType(conceptTypes []string, includeDeprecated bool, searchAllAuthorities bool) ([]service.Concept, error) {
-	if len(conceptTypes) != 1 {
+	if len(conceptTypes) == 0 {
+		return []service.Concept{}, nil
+	}
+
+	if len(conceptTypes) > 1 {
 		return nil, NewValidationError("only a single type is supported by this kind of request")
 	}
 

--- a/resources/handler.go
+++ b/resources/handler.go
@@ -118,7 +118,7 @@ func (h *Handler) findConceptsByType(conceptTypes []string, includeDeprecated bo
 		return h.service.FindAllConceptsByDirectType(conceptTypes[0], searchAllAuthorities, includeDeprecated)
 	}
 
-	return h.service.FindAllConceptsByType(conceptTypes[0], includeDeprecated)
+	return h.service.FindAllConceptsByType(conceptTypes[0], searchAllAuthorities, includeDeprecated)
 }
 
 func writeHTTPError(w http.ResponseWriter, status int, err error) {

--- a/resources/handler_test.go
+++ b/resources/handler_test.go
@@ -25,8 +25,8 @@ type mockConceptSearchService struct {
 	mock.Mock
 }
 
-func (s *mockConceptSearchService) FindAllConceptsByType(conceptType string, includeDeprecated bool) ([]service.Concept, error) {
-	args := s.Called(conceptType, includeDeprecated)
+func (s *mockConceptSearchService) FindAllConceptsByType(conceptType string, searchAllAuthorities bool, includeDeprecated bool) ([]service.Concept, error) {
+	args := s.Called(conceptType, searchAllAuthorities, includeDeprecated)
 	return args.Get(0).([]service.Concept), args.Error(1)
 }
 
@@ -76,7 +76,7 @@ func TestAllConceptsByType(t *testing.T) {
 
 	concepts := dummyConcepts()
 	svc := &mockConceptSearchService{}
-	svc.On("FindAllConceptsByType", "http://www.ft.com/ontology/Genre", mock.AnythingOfType("bool")).Return(concepts, nil)
+	svc.On("FindAllConceptsByType", "http://www.ft.com/ontology/Genre", mock.AnythingOfType("bool"), mock.AnythingOfType("bool")).Return(concepts, nil)
 
 	actual := doHttpCall(svc, req)
 
@@ -92,7 +92,7 @@ func TestAllConceptsByType(t *testing.T) {
 func TestAllConceptsByTypeInputError(t *testing.T) {
 	req := httptest.NewRequest("GET", "/concepts?type=http%3A%2F%2Fwww.ft.com%2Fontology%2FFoo", nil)
 	svc := &mockConceptSearchService{}
-	svc.On("FindAllConceptsByType", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return([]service.Concept{}, expectedInputErr)
+	svc.On("FindAllConceptsByType", mock.AnythingOfType("string"), mock.AnythingOfType("bool"), mock.AnythingOfType("bool")).Return([]service.Concept{}, expectedInputErr)
 
 	actual := doHttpCall(svc, req)
 
@@ -107,7 +107,7 @@ func TestAllConceptsByTypeInputError(t *testing.T) {
 func TestAllConceptByTypeNoElasticsearchError(t *testing.T) {
 	req := httptest.NewRequest("GET", "/concepts?type=http%3A%2F%2Fwww.ft.com%2Fontology%2FFoo", nil)
 	svc := &mockConceptSearchService{}
-	svc.On("FindAllConceptsByType", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return([]service.Concept{}, elastic.ErrNoClient)
+	svc.On("FindAllConceptsByType", mock.AnythingOfType("string"), mock.AnythingOfType("bool"), mock.AnythingOfType("bool")).Return([]service.Concept{}, elastic.ErrNoClient)
 
 	actual := doHttpCall(svc, req)
 
@@ -122,7 +122,7 @@ func TestAllConceptByTypeNoElasticsearchError(t *testing.T) {
 func TestAllConceptByTypeNoElasticsearchClientError(t *testing.T) {
 	req := httptest.NewRequest("GET", "/concepts?type=http%3A%2F%2Fwww.ft.com%2Fontology%2FFoo", nil)
 	svc := &mockConceptSearchService{}
-	svc.On("FindAllConceptsByType", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return([]service.Concept{}, util.ErrNoElasticClient)
+	svc.On("FindAllConceptsByType", mock.AnythingOfType("string"), mock.AnythingOfType("bool"), mock.AnythingOfType("bool")).Return([]service.Concept{}, util.ErrNoElasticClient)
 
 	actual := doHttpCall(svc, req)
 
@@ -139,7 +139,7 @@ func TestAllConceptByTypeServerError(t *testing.T) {
 
 	expectedError := errors.New("Test error")
 	svc := &mockConceptSearchService{}
-	svc.On("FindAllConceptsByType", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return([]service.Concept{}, expectedError)
+	svc.On("FindAllConceptsByType", mock.AnythingOfType("string"), mock.AnythingOfType("bool"), mock.AnythingOfType("bool")).Return([]service.Concept{}, expectedError)
 
 	actual := doHttpCall(svc, req)
 
@@ -428,7 +428,7 @@ func TestDeprecatedTypes(t *testing.T) {
 
 	concepts := dummyConcepts()
 	svc := &mockConceptSearchService{}
-	svc.On("FindAllConceptsByType", "http://www.ft.com/ontology/Genre", true).Return(concepts, nil)
+	svc.On("FindAllConceptsByType", "http://www.ft.com/ontology/Genre", mock.AnythingOfType("bool"), true).Return(concepts, nil)
 
 	actual := doHttpCall(svc, req)
 
@@ -446,7 +446,7 @@ func TestWrongDeprecatedFlagVal(t *testing.T) {
 
 	concepts := dummyConcepts()
 	svc := &mockConceptSearchService{}
-	svc.On("FindAllConceptsByType", "http://www.ft.com/ontology/Genre", mock.AnythingOfType("bool")).Return(concepts, nil)
+	svc.On("FindAllConceptsByType", "http://www.ft.com/ontology/Genre", mock.AnythingOfType("bool"), mock.AnythingOfType("bool")).Return(concepts, nil)
 
 	actual := doHttpCall(svc, req)
 

--- a/resources/handler_test.go
+++ b/resources/handler_test.go
@@ -30,6 +30,11 @@ func (s *mockConceptSearchService) FindAllConceptsByType(conceptType string, inc
 	return args.Get(0).([]service.Concept), args.Error(1)
 }
 
+func (s *mockConceptSearchService) FindAllConceptsByDirectType(conceptType string, searchAllAuthorities bool, includeDeprecated bool) ([]service.Concept, error) {
+	args := s.Called(conceptType, includeDeprecated)
+	return args.Get(0).([]service.Concept), args.Error(1)
+}
+
 func (s *mockConceptSearchService) FindConceptsById(ids []string) ([]service.Concept, error) {
 	args := s.Called(ids)
 	return args.Get(0).([]service.Concept), args.Error(1)

--- a/resources/handler_test.go
+++ b/resources/handler_test.go
@@ -40,8 +40,8 @@ func (s *mockConceptSearchService) FindConceptsById(ids []string) ([]service.Con
 	return args.Get(0).([]service.Concept), args.Error(1)
 }
 
-func (s *mockConceptSearchService) SearchConceptByTextAndTypes(textQuery string, conceptTypes []string, includeDeprecated bool) ([]service.Concept, error) {
-	args := s.Called(textQuery, conceptTypes, includeDeprecated)
+func (s *mockConceptSearchService) SearchConceptByTextAndTypes(textQuery string, conceptTypes []string, searchAllAuthorities bool, includeDeprecated bool) ([]service.Concept, error) {
+	args := s.Called(textQuery, conceptTypes, searchAllAuthorities, includeDeprecated)
 	return args.Get(0).([]service.Concept), args.Error(1)
 }
 
@@ -49,8 +49,8 @@ func (s *mockConceptSearchService) SetElasticClient(client *elastic.Client) {
 	s.Called(client)
 }
 
-func (s *mockConceptSearchService) SearchConceptByTextAndTypesWithBoost(textQuery string, conceptTypes []string, boostType string, includeDeprecated bool) ([]service.Concept, error) {
-	args := s.Called(textQuery, conceptTypes, boostType, includeDeprecated)
+func (s *mockConceptSearchService) SearchConceptByTextAndTypesWithBoost(textQuery string, conceptTypes []string, boostType string, searchAllAuthorities bool, includeDeprecated bool) ([]service.Concept, error) {
+	args := s.Called(textQuery, conceptTypes, boostType, searchAllAuthorities, includeDeprecated)
 	return args.Get(0).([]service.Concept), args.Error(1)
 }
 
@@ -386,7 +386,7 @@ func TestConceptSearchForAuthors(t *testing.T) {
 	svc := &mockConceptSearchService{}
 
 	concepts := dummyConcepts()
-	svc.On("SearchConceptByTextAndTypesWithBoost", "pippo", []string{"http://www.ft.com/ontology/person/Person"}, "authors", mock.AnythingOfType("bool")).Return(concepts, nil)
+	svc.On("SearchConceptByTextAndTypesWithBoost", "pippo", []string{"http://www.ft.com/ontology/person/Person"}, "authors", mock.AnythingOfType("bool"), mock.AnythingOfType("bool")).Return(concepts, nil)
 
 	actual := doHttpCall(svc, req)
 
@@ -404,7 +404,7 @@ func TestConceptSearchInvalidBoost(t *testing.T) {
 	req := httptest.NewRequest("GET", "/concepts?type=http%3A%2F%2Fwww.ft.com%2Fontology%2Fperson%2FPerson&q=pippo&mode=search&boost=somethingThatWeDontSupport", nil)
 
 	svc := &mockConceptSearchService{}
-	svc.On("SearchConceptByTextAndTypesWithBoost", "pippo", []string{"http://www.ft.com/ontology/person/Person"}, "somethingThatWeDontSupport", mock.AnythingOfType("bool")).Return([]service.Concept{}, expectedInputErr)
+	svc.On("SearchConceptByTextAndTypesWithBoost", "pippo", []string{"http://www.ft.com/ontology/person/Person"}, "somethingThatWeDontSupport", mock.AnythingOfType("bool"), mock.AnythingOfType("bool")).Return([]service.Concept{}, expectedInputErr)
 
 	actual := doHttpCall(svc, req)
 
@@ -437,7 +437,7 @@ func TestSearchMode(t *testing.T) {
 	svc := &mockConceptSearchService{}
 
 	concepts := dummyConcepts()
-	svc.On("SearchConceptByTextAndTypes", "pippo", []string{"http://www.ft.com/ontology/person/Person"}, mock.AnythingOfType("bool")).Return(concepts, nil)
+	svc.On("SearchConceptByTextAndTypes", "pippo", []string{"http://www.ft.com/ontology/person/Person"}, mock.AnythingOfType("bool"), mock.AnythingOfType("bool")).Return(concepts, nil)
 
 	actual := doHttpCall(svc, req)
 

--- a/service/search.go
+++ b/service/search.go
@@ -24,14 +24,15 @@ type ConceptSearchService interface {
 	SetElasticClient(client *elastic.Client)
 	FindConceptsById(ids []string) ([]Concept, error)
 	FindAllConceptsByType(conceptType string, includeDeprecated bool) ([]Concept, error)
-	FindAllConceptsByDirectType(conceptType string, includeDeprecated bool) ([]Concept, error)
+	FindAllConceptsByDirectType(conceptType string, searchAllAuthorities bool, includeDeprecated bool) ([]Concept, error)
 	SearchConceptByTextAndTypes(textQuery string, conceptTypes []string, includeDeprecated bool) ([]Concept, error)
 	SearchConceptByTextAndTypesWithBoost(textQuery string, conceptTypes []string, boostType string, includeDeprecated bool) ([]Concept, error)
 }
 
 type esConceptSearchService struct {
 	esClient               *elastic.Client
-	index                  string
+	defaultIndex           string
+	extendedSearchIndex    string
 	maxSearchResults       int
 	maxAutoCompleteResults int
 	mappingRefreshTicker   *time.Ticker
@@ -40,9 +41,10 @@ type esConceptSearchService struct {
 	clientLock             *sync.RWMutex
 }
 
-func NewEsConceptSearchService(index string, maxSearchResults int, maxAutoCompleteResults int, authorsBoost int) ConceptSearchService {
+func NewEsConceptSearchService(defaultIndex string, extendedSearchIndex string, maxSearchResults int, maxAutoCompleteResults int, authorsBoost int) ConceptSearchService {
 	return &esConceptSearchService{
-		index:                  index,
+		defaultIndex:           defaultIndex,
+		extendedSearchIndex:    extendedSearchIndex,
 		maxSearchResults:       maxSearchResults,
 		maxAutoCompleteResults: maxAutoCompleteResults,
 		authorsBoost:           authorsBoost,
@@ -67,7 +69,7 @@ func (s *esConceptSearchService) FindAllConceptsByType(conceptType string, inclu
 		return nil, err
 	}
 
-	query := s.esClient.Search(s.index).Type(t).Size(s.maxSearchResults)
+	query := s.esClient.Search(s.defaultIndex).Type(t).Size(s.maxSearchResults)
 	if !includeDeprecated {
 		deprecatedQ := elastic.NewBoolQuery().MustNot(elastic.NewTermQuery("isDeprecated", true))
 		query = query.Query(deprecatedQ)
@@ -83,11 +85,12 @@ func (s *esConceptSearchService) FindAllConceptsByType(conceptType string, inclu
 	return concepts, nil
 }
 
-func (s *esConceptSearchService) FindAllConceptsByDirectType(conceptType string, includeDeprecated bool) ([]Concept, error) {
+func (s *esConceptSearchService) FindAllConceptsByDirectType(conceptType string, searchAllAuthorities bool, includeDeprecated bool) ([]Concept, error) {
 	directTypeMatch := elastic.NewMatchQuery("directType", conceptType)
 	mustQuery := elastic.NewBoolQuery().Should(directTypeMatch)
+	index := s.getIndexForAuthoritiesParam(searchAllAuthorities)
 
-	result, err := s.esClient.Search(s.index).Size(s.maxSearchResults).Query(mustQuery).Do(context.Background())
+	result, err := s.esClient.Search(index).Size(s.maxSearchResults).Query(mustQuery).Do(context.Background())
 	if err != nil {
 		log.Errorf("error: %v", err)
 		return nil, err
@@ -105,7 +108,7 @@ func (s *esConceptSearchService) FindConceptsById(ids []string) ([]Concept, erro
 		return nil, err
 	}
 	idsQuery := elastic.NewIdsQuery("_all").Ids(ids...)
-	result, err := s.esClient.Search(s.index).Size(s.maxSearchResults).Query(idsQuery).Do(context.Background())
+	result, err := s.esClient.Search(s.defaultIndex).Size(s.maxSearchResults).Query(idsQuery).Do(context.Background())
 	if err != nil {
 		log.Errorf("error: %v", err)
 		return nil, err
@@ -223,7 +226,7 @@ func (s *esConceptSearchService) searchConceptsForMultipleTypes(textQuery string
 
 	theQuery := elastic.NewBoolQuery().Must(mustQuery).Should(shouldMatch...).MustNot(mustNotMatch...).Filter(typeFilter).MinimumNumberShouldMatch(0).Boost(1)
 
-	search := s.esClient.Search(s.index).Size(s.maxAutoCompleteResults).Query(theQuery)
+	search := s.esClient.Search(s.defaultIndex).Size(s.maxAutoCompleteResults).Query(theQuery)
 
 	result, err := search.SearchType("dfs_query_then_fetch").Do(context.Background())
 	if err != nil {
@@ -253,4 +256,12 @@ func (s *esConceptSearchService) elasticClient() *elastic.Client {
 	s.clientLock.RLock()
 	defer s.clientLock.RUnlock()
 	return s.esClient
+}
+
+func (s *esConceptSearchService) getIndexForAuthoritiesParam(searchAllAuthorities bool) string {
+	if searchAllAuthorities {
+		return s.extendedSearchIndex
+	}
+
+	return s.defaultIndex
 }

--- a/service/search_test.go
+++ b/service/search_test.go
@@ -39,7 +39,7 @@ const (
 func TestNoElasticClient(t *testing.T) {
 	service := NewEsConceptSearchService("test", "", 50, 10, 2)
 
-	_, err := service.FindAllConceptsByType(ftGenreType, true)
+	_, err := service.FindAllConceptsByType(ftGenreType, false, true)
 	assert.EqualError(t, err, util.ErrNoElasticClient.Error(), "error response")
 
 	_, err = service.SearchConceptByTextAndTypes("lucy", []string{ftBrandType}, true)
@@ -301,7 +301,7 @@ func (s *EsConceptSearchServiceTestSuite) TestFindAllConceptsByType() {
 	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
-	concepts, err := service.FindAllConceptsByType(ftGenreType, true)
+	concepts, err := service.FindAllConceptsByType(ftGenreType, false, true)
 
 	assert.NoError(s.T(), err, "expected no error for ES read")
 	assert.Len(s.T(), concepts, 4, "there should be four genres")
@@ -319,7 +319,7 @@ func (s *EsConceptSearchServiceTestSuite) TestFindAllConceptsByType() {
 func (s *EsConceptSearchServiceTestSuite) TestFindAllConceptsByTypeResultSize() {
 	service := NewEsConceptSearchService(testDefaultIndex, "", 3, 10, 2)
 	service.SetElasticClient(s.ec)
-	concepts, err := service.FindAllConceptsByType(ftGenreType, true)
+	concepts, err := service.FindAllConceptsByType(ftGenreType, false, true)
 
 	assert.NoError(s.T(), err, "expected no error for ES read")
 	assert.Len(s.T(), concepts, 3, "there should be three genres")
@@ -338,7 +338,7 @@ func (s *EsConceptSearchServiceTestSuite) TestFindAllConceptsByTypeInvalid() {
 	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
-	_, err := service.FindAllConceptsByType("http://www.ft.com/ontology/Foo", true)
+	_, err := service.FindAllConceptsByType("http://www.ft.com/ontology/Foo", false, true)
 
 	assert.EqualError(s.T(), err, fmt.Sprintf(util.ErrInvalidConceptTypeFormat, "http://www.ft.com/ontology/Foo"), "expected error")
 }
@@ -363,7 +363,7 @@ func (s *EsConceptSearchServiceTestSuite) TestFindAllConceptsByTypeDeprecatedFla
 	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
-	conceptsWithoutDeprecated, err := service.FindAllConceptsByType("http://www.ft.com/ontology/person/Person", false)
+	conceptsWithoutDeprecated, err := service.FindAllConceptsByType("http://www.ft.com/ontology/person/Person", false, false)
 	assert.NoError(s.T(), err, "no error expected")
 
 	for _, concept := range conceptsWithoutDeprecated {
@@ -371,7 +371,7 @@ func (s *EsConceptSearchServiceTestSuite) TestFindAllConceptsByTypeDeprecatedFla
 		assert.False(s.T(), concept.IsDeprecated)
 	}
 
-	conceptsWithDeprecated, err := service.FindAllConceptsByType("http://www.ft.com/ontology/person/Person", true)
+	conceptsWithDeprecated, err := service.FindAllConceptsByType("http://www.ft.com/ontology/person/Person", false, true)
 	assert.NoError(s.T(), err, "no error expected")
 
 	deprecatedConceptsFound := 0

--- a/service/search_test.go
+++ b/service/search_test.go
@@ -106,7 +106,6 @@ func getElasticSearchTestURL(t *testing.T) string {
 	}
 
 	esURL := os.Getenv("ELASTICSEARCH_TEST_URL")
-	esURL = "http://localhost:9200"
 	if strings.TrimSpace(esURL) == "" {
 		t.Fatal("Please set the environment variable ELASTICSEARCH_TEST_URL to run ElasticSearch integration tests (e.g. export ELASTICSEARCH_TEST_URL=http://localhost:9200). Alternatively, run `go test -short` to skip them.")
 	}

--- a/service/search_test.go
+++ b/service/search_test.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	apiBaseURL             = "http://test.api.ft.com"
-	testIndexName          = "test-index"
+	testDefaultIndex       = "test-index"
 	esGenreType            = "genres"
 	esBrandType            = "brands"
 	esPeopleType           = "people"
@@ -37,7 +37,7 @@ const (
 )
 
 func TestNoElasticClient(t *testing.T) {
-	service := NewEsConceptSearchService("test", 50, 10, 2)
+	service := NewEsConceptSearchService("test", "", 50, 10, 2)
 
 	_, err := service.FindAllConceptsByType(ftGenreType, true)
 	assert.EqualError(t, err, util.ErrNoElasticClient.Error(), "error response")
@@ -89,7 +89,7 @@ func (s *EsConceptSearchServiceTestSuite) SetupSuite() {
 }
 
 func (s *EsConceptSearchServiceTestSuite) TearDownSuite() {
-	s.ec.DeleteIndex(testIndexName).Do(context.Background())
+	s.ec.DeleteIndex(testDefaultIndex).Do(context.Background())
 }
 
 func getElasticSearchTestURL(t *testing.T) string {
@@ -110,7 +110,7 @@ func createIndex(ec *elastic.Client, mappingFile string) error {
 	if err != nil {
 		return err
 	}
-	_, err = ec.CreateIndex(testIndexName).Body(string(mapping)).Do(context.Background())
+	_, err = ec.CreateIndex(testDefaultIndex).Body(string(mapping)).Do(context.Background())
 	if err != nil {
 		return err
 	}
@@ -120,13 +120,13 @@ func createIndex(ec *elastic.Client, mappingFile string) error {
 func cleanup(t *testing.T, ec *elastic.Client, esType string, uuids ...string) {
 	for _, uuid := range uuids {
 		_, err := ec.Delete().
-			Index(testIndexName).
+			Index(testDefaultIndex).
 			Type(esType).
 			Id(uuid).
 			Do(context.TODO())
 		assert.NoError(t, err)
 	}
-	_, err := ec.Refresh(testIndexName).Do(context.TODO())
+	_, err := ec.Refresh(testDefaultIndex).Do(context.TODO())
 	assert.NoError(t, err)
 }
 
@@ -147,7 +147,7 @@ func writeTestAuthors(ec *elastic.Client, amount int) error {
 		}
 
 		_, err := ec.Index().
-			Index(testIndexName).
+			Index(testDefaultIndex).
 			Type(esPeopleType).
 			Id(uuid).
 			BodyJson(payload).
@@ -158,7 +158,7 @@ func writeTestAuthors(ec *elastic.Client, amount int) error {
 	}
 
 	// ensure test data is immediately available from the index
-	_, err := ec.Refresh(testIndexName).Do(context.Background())
+	_, err := ec.Refresh(testDefaultIndex).Do(context.Background())
 	if err != nil {
 		return err
 	}
@@ -176,7 +176,7 @@ func writeTestConcepts(ec *elastic.Client, esConceptType string, ftConceptType s
 	}
 
 	// ensure test data is immediately available from the index
-	_, err := ec.Refresh(testIndexName).Do(context.Background())
+	_, err := ec.Refresh(testDefaultIndex).Do(context.Background())
 	if err != nil {
 		return err
 	}
@@ -195,7 +195,7 @@ func writeTestPerson(ec *elastic.Client, uuid string, prefLabel string, ftAuthor
 	}
 
 	_, err := ec.Index().
-		Index(testIndexName).
+		Index(testDefaultIndex).
 		Type(esPeopleType).
 		Id(uuid).
 		BodyJson(payload).
@@ -218,7 +218,7 @@ func writeTestConcept(ec *elastic.Client, uuid string, esConceptType string, ftC
 	}
 
 	_, err := ec.Index().
-		Index(testIndexName).
+		Index(testDefaultIndex).
 		Type(esConceptType).
 		Id(uuid).
 		BodyJson(payload).
@@ -244,7 +244,7 @@ func writeTestConceptWithScopeNote(ec *elastic.Client, uuid string, esConceptTyp
 	}
 
 	_, err := ec.Index().
-		Index(testIndexName).
+		Index(testDefaultIndex).
 		Type(esConceptType).
 		Id(uuid).
 		BodyJson(payload).
@@ -271,7 +271,7 @@ func writeTestConceptWithCountryCodeAndCountryOfIncorporation(ec *elastic.Client
 	}
 
 	_, err := ec.Index().
-		Index(testIndexName).
+		Index(testDefaultIndex).
 		Type(esConceptType).
 		Id(uuid).
 		BodyJson(payload).
@@ -285,7 +285,7 @@ func writeTestConceptWithCountryCodeAndCountryOfIncorporation(ec *elastic.Client
 
 func writeTestConceptModel(ec *elastic.Client, esConceptType string, model EsConceptModel) error {
 	_, err := ec.Index().
-		Index(testIndexName).
+		Index(testDefaultIndex).
 		Type(esConceptType).
 		Id(model.Id).
 		BodyJson(model).
@@ -298,7 +298,7 @@ func writeTestConceptModel(ec *elastic.Client, esConceptType string, model EsCon
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestFindAllConceptsByType() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	concepts, err := service.FindAllConceptsByType(ftGenreType, true)
@@ -317,7 +317,7 @@ func (s *EsConceptSearchServiceTestSuite) TestFindAllConceptsByType() {
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestFindAllConceptsByTypeResultSize() {
-	service := NewEsConceptSearchService(testIndexName, 3, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 3, 10, 2)
 	service.SetElasticClient(s.ec)
 	concepts, err := service.FindAllConceptsByType(ftGenreType, true)
 
@@ -335,7 +335,7 @@ func (s *EsConceptSearchServiceTestSuite) TestFindAllConceptsByTypeResultSize() 
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestFindAllConceptsByTypeInvalid() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	_, err := service.FindAllConceptsByType("http://www.ft.com/ontology/Foo", true)
@@ -344,7 +344,7 @@ func (s *EsConceptSearchServiceTestSuite) TestFindAllConceptsByTypeInvalid() {
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestFindAllConceptsByTypeDeprecatedFlag() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	uuid := uuid.NewV4().String()
@@ -360,7 +360,7 @@ func (s *EsConceptSearchServiceTestSuite) TestFindAllConceptsByTypeDeprecatedFla
 		IsDeprecated: true,
 	})
 	assert.NoError(s.T(), err, "no error expected during indexing a new person concept")
-	_, err = s.ec.Refresh(testIndexName).Do(context.Background())
+	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
 	conceptsWithoutDeprecated, err := service.FindAllConceptsByType("http://www.ft.com/ontology/person/Person", false)
@@ -389,7 +389,7 @@ func (s *EsConceptSearchServiceTestSuite) TestFindAllConceptsByTypeDeprecatedFla
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypes() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	concepts, err := service.SearchConceptByTextAndTypes("test", []string{ftPeopleType}, true)
@@ -402,7 +402,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypes() {
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesMultipleTypes() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	concepts, err := service.SearchConceptByTextAndTypes("test", []string{ftBrandType, ftAlphavilleSeriesType}, true)
@@ -415,7 +415,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesMultipl
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesNoText() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	_, err := service.SearchConceptByTextAndTypes("", []string{ftPeopleType}, true)
@@ -426,10 +426,10 @@ func (s *EsConceptSearchServiceTestSuite) TestFindConceptsByIdsSingle() {
 	uuid1 := uuid.NewV4().String()
 	err := writeTestConcept(s.ec, uuid1, esPeopleType, ftPeopleType, "Eric Phillips inc", []string{}, nil)
 	require.NoError(s.T(), err)
-	_, err = s.ec.Refresh(testIndexName).Do(context.Background())
+	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	concepts, err := service.FindConceptsById([]string{uuid1})
@@ -450,10 +450,10 @@ func (s *EsConceptSearchServiceTestSuite) TestFindConceptsByIdsMultiple() {
 	err = writeTestConcept(s.ec, uuid2, esLocationType, ftLocationType, "little pond", []string{}, nil)
 	require.NoError(s.T(), err)
 
-	_, err = s.ec.Refresh(testIndexName).Do(context.Background())
+	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	testIds := []string{uuid1, uuid2}
@@ -473,7 +473,7 @@ func (s *EsConceptSearchServiceTestSuite) TestFindConceptsByIdsMultiple() {
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestFindConceptsByIdsSingleInvalidUUID() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	concepts, err := service.FindConceptsById([]string{"uuid1"})
@@ -491,10 +491,10 @@ func (s *EsConceptSearchServiceTestSuite) TestFindConceptsByIdsMultipleMixValidI
 	err = writeTestConcept(s.ec, uuid2, esLocationType, ftLocationType, "big pond", []string{}, nil)
 	require.NoError(s.T(), err)
 
-	_, err = s.ec.Refresh(testIndexName).Do(context.Background())
+	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	testIds := []string{uuid1, "xxx", uuid2, "zzzz"}
@@ -515,7 +515,7 @@ func (s *EsConceptSearchServiceTestSuite) TestFindConceptsByIdsMultipleMixValidI
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestFindConceptsByIdsEmptyStringValue() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	_, err := service.FindConceptsById([]string{""})
@@ -523,7 +523,7 @@ func (s *EsConceptSearchServiceTestSuite) TestFindConceptsByIdsEmptyStringValue(
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestFindConceptsByIdsEmptySlice() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	_, err := service.FindConceptsById([]string{})
@@ -531,7 +531,7 @@ func (s *EsConceptSearchServiceTestSuite) TestFindConceptsByIdsEmptySlice() {
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestFindConceptsByIdsNilSlice() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	_, err := service.FindConceptsById(nil)
@@ -539,7 +539,7 @@ func (s *EsConceptSearchServiceTestSuite) TestFindConceptsByIdsNilSlice() {
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesNoConceptTypes() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	_, err := service.SearchConceptByTextAndTypes("pippo", []string{}, true)
@@ -547,7 +547,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesNoConce
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesInvalidConceptType() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	_, err := service.SearchConceptByTextAndTypes("pippo", []string{"http://www.ft.com/ontology/Foo"}, true)
@@ -555,7 +555,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesInvalid
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesTermMatchBoosted() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	uuid1 := uuid.NewV4().String()
@@ -566,7 +566,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesTermMat
 	err = writeTestConcept(s.ec, uuid2, esPeopleType, ftPeopleType, "Donald J Trump", []string{}, nil)
 	require.NoError(s.T(), err)
 
-	_, err = s.ec.Refresh(testIndexName).Do(context.Background())
+	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
 	concepts, err := service.SearchConceptByTextAndTypes("donald trump", []string{ftPeopleType}, true)
@@ -582,7 +582,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesTermMat
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesExactMatchBoosted() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	uuid1 := uuid.NewV4().String()
@@ -593,7 +593,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesExactMa
 	err = writeTestConcept(s.ec, uuid2, esLocationType, ftLocationType, "New York City Magistrates (New York, New York)", []string{}, nil)
 	require.NoError(s.T(), err)
 
-	_, err = s.ec.Refresh(testIndexName).Do(context.Background())
+	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
 	concepts, err := service.SearchConceptByTextAndTypes("new york", []string{ftLocationType}, true)
@@ -609,7 +609,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesExactMa
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesExactMatchBoostedWithScopeNotePresent() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	uuid1 := uuid.NewV4().String()
@@ -620,7 +620,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesExactMa
 	err = writeTestConceptWithScopeNote(s.ec, uuid2, esLocationType, ftLocationType, "New York City Magistrates (New York, New York)", []string{}, "New York City Magistrates scopeNote")
 	require.NoError(s.T(), err)
 
-	_, err = s.ec.Refresh(testIndexName).Do(context.Background())
+	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
 	concepts, err := service.SearchConceptByTextAndTypes("new yor", []string{ftLocationType}, true)
@@ -636,7 +636,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesExactMa
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesDeprecated() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	uuid1 := uuid.NewV4().String()
@@ -655,7 +655,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesDepreca
 	})
 	require.NoError(s.T(), err)
 
-	_, err = s.ec.Refresh(testIndexName).Do(context.Background())
+	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
 	concepts, err := service.SearchConceptByTextAndTypes("new york", []string{ftLocationType}, true)
@@ -680,7 +680,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesDepreca
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithAuthorsBoost() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	uuid1 := uuid.NewV4().String()
@@ -695,7 +695,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithAut
 	err = writeTestPerson(s.ec, uuid3, "Robert Author Shrimpley", "true")
 	require.NoError(s.T(), err)
 
-	_, err = s.ec.Refresh(testIndexName).Do(context.Background())
+	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
 	concepts, err := service.SearchConceptByTextAndTypesWithBoost("robert shrimpley", []string{ftPeopleType}, "authors", true)
@@ -714,7 +714,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithAut
 
 // If 4 concepts are equivalent, then the type boosts should order them as expected.
 func (s *EsConceptSearchServiceTestSuite) TestSearch__SpecificTypesAreBoosted() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	uuid1 := uuid.NewV4().String()
@@ -733,7 +733,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearch__SpecificTypesAreBoosted() 
 	err = writeTestConcept(s.ec, uuid4, esTopicType, ftTopicType, "Fannie Mae", []string{}, nil)
 	require.NoError(s.T(), err)
 
-	_, err = s.ec.Refresh(testIndexName).Do(context.Background())
+	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
 	concepts, err := service.SearchConceptByTextAndTypes("Fannie Mae", []string{ftPeopleType, ftTopicType, ftLocationType, ftOrganisationType}, true)
@@ -757,7 +757,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearch__SpecificTypesAreBoosted() 
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithAuthorsBoostAndDeprecated() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	uuid1 := uuid.NewV4().String()
@@ -786,7 +786,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithAut
 	})
 	require.NoError(s.T(), err)
 
-	_, err = s.ec.Refresh(testIndexName).Do(context.Background())
+	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
 	conceptsWithDeprecated, err := service.SearchConceptByTextAndTypesWithBoost("robert shrimpley", []string{ftPeopleType}, "authors", true)
@@ -819,7 +819,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithAut
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByExactMatchAliases() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	uuid1 := uuid.NewV4().String()
@@ -830,7 +830,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByExactMatchAliases(
 	err = writeTestConcept(s.ec, uuid2, esLocationType, ftLocationType, "USADA", []string{}, nil)
 	require.NoError(s.T(), err)
 
-	_, err = s.ec.Refresh(testIndexName).Do(context.Background())
+	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
 	concepts, err := service.SearchConceptByTextAndTypes("USA", []string{ftLocationType}, true)
@@ -846,7 +846,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByExactMatchAliases(
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoostRestrictedSize() {
-	service := NewEsConceptSearchService(testIndexName, 10, 1, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 1, 2)
 	service.SetElasticClient(s.ec)
 
 	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{ftPeopleType}, "authors", true)
@@ -855,7 +855,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoo
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoostNoInputText() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	concepts, err := service.SearchConceptByTextAndTypesWithBoost("", []string{ftPeopleType}, "authors", true)
@@ -864,7 +864,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoo
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoostNoTypes() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{}, "authors", true)
@@ -873,7 +873,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoo
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoostMultipleTypes() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{ftPeopleType, ftLocationType}, "authors", true)
@@ -882,7 +882,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoo
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithInvalidBoost() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{ftPeopleType}, "pluto", true)
@@ -891,7 +891,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithInv
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoostNoESConnection() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 
 	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{ftPeopleType}, "authors", true)
 	assert.EqualError(s.T(), err, util.ErrNoElasticClient.Error())
@@ -899,7 +899,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoo
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoostInvalidConceptType() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 
 	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{ftGenreType}, "authors", true)
 	assert.EqualError(s.T(), err, fmt.Sprintf(util.ErrInvalidConceptTypeFormat, ftGenreType))
@@ -907,7 +907,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoo
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByPopularity() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	uuid1 := uuid.NewV4().String()
@@ -918,7 +918,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByPopularity() {
 	err = writeTestConcept(s.ec, uuid2, esLocationType, ftLocationType, "USADA", []string{"USA"}, &ConceptMetrics{AnnotationsCount: 4})
 	require.NoError(s.T(), err)
 
-	_, err = s.ec.Refresh(testIndexName).Do(context.Background())
+	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
 	concepts, err := service.SearchConceptByTextAndTypes("USA", []string{ftLocationType}, true)
@@ -934,7 +934,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByPopularity() {
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByPopularityAliasMatch() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	uuid1 := uuid.NewV4().String()
@@ -945,7 +945,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByPopularityAliasMat
 	err = writeTestConcept(s.ec, uuid2, esLocationType, ftLocationType, "Luca The Fraud", []string{"Dr Git"}, &ConceptMetrics{AnnotationsCount: 4})
 	require.NoError(s.T(), err)
 
-	_, err = s.ec.Refresh(testIndexName).Do(context.Background())
+	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
 	concepts, err := service.SearchConceptByTextAndTypes("Dr G", []string{ftLocationType}, true)
@@ -961,7 +961,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByPopularityAliasMat
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByRecentPopularitySameAnnotationsCount() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	uuid1 := uuid.NewV4().String()
@@ -972,7 +972,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByRecentPopularitySa
 	err = writeTestConcept(s.ec, uuid2, esLocationType, ftLocationType, "USADA", []string{"USA"}, &ConceptMetrics{PrevWeekAnnotationsCount: 2, AnnotationsCount: 10})
 	require.NoError(s.T(), err)
 
-	_, err = s.ec.Refresh(testIndexName).Do(context.Background())
+	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
 	concepts, err := service.SearchConceptByTextAndTypes("USA", []string{ftLocationType}, true)
@@ -988,7 +988,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByRecentPopularitySa
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByRecentPopularityNoRecentAnnotations() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	uuid1 := uuid.NewV4().String()
@@ -999,7 +999,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByRecentPopularityNo
 	err = writeTestConcept(s.ec, uuid2, esLocationType, ftLocationType, "USADA", []string{"USA"}, &ConceptMetrics{PrevWeekAnnotationsCount: 0, AnnotationsCount: 10})
 	require.NoError(s.T(), err)
 
-	_, err = s.ec.Refresh(testIndexName).Do(context.Background())
+	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
 	concepts, err := service.SearchConceptByTextAndTypes("USA", []string{ftLocationType}, true)
@@ -1015,7 +1015,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByRecentPopularityNo
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByRecentPopularity() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	uuid1 := uuid.NewV4().String()
@@ -1026,7 +1026,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByRecentPopularity()
 	err = writeTestConcept(s.ec, uuid2, esLocationType, ftLocationType, "USADA", []string{"USA"}, &ConceptMetrics{PrevWeekAnnotationsCount: 20, AnnotationsCount: 100})
 	require.NoError(s.T(), err)
 
-	_, err = s.ec.Refresh(testIndexName).Do(context.Background())
+	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
 	concepts, err := service.SearchConceptByTextAndTypes("USA", []string{ftLocationType}, true)
@@ -1042,7 +1042,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByRecentPopularity()
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByAliasPartialMatch() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	uuid1 := uuid.NewV4().String()
@@ -1053,7 +1053,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByAliasPartialMatch(
 	err = writeTestConcept(s.ec, uuid2, esLocationType, ftLocationType, "USADA", []string{"USA"}, &ConceptMetrics{AnnotationsCount: 0})
 	require.NoError(s.T(), err)
 
-	_, err = s.ec.Refresh(testIndexName).Do(context.Background())
+	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
 	concepts, err := service.SearchConceptByTextAndTypes("roose", []string{ftLocationType}, true)
@@ -1067,14 +1067,14 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByAliasPartialMatch(
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestFindOrganisationWithCountryCodeAndCountryOfIncorporation() {
-	service := NewEsConceptSearchService(testIndexName, 10, 10, 2)
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
 	uuid := uuid.NewV4().String()
 	err := writeTestConceptWithCountryCodeAndCountryOfIncorporation(s.ec, uuid, esOrganisationType, ftOrganisationType, "MooTech Ltd.", []string{"MooTech Ltd."}, "CA", "US")
 	require.NoError(s.T(), err)
 
-	_, err = s.ec.Refresh(testIndexName).Do(context.Background())
+	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
 	concepts, err := service.SearchConceptByTextAndTypes("Moo", []string{ftOrganisationType}, false)

--- a/service/search_test.go
+++ b/service/search_test.go
@@ -19,7 +19,6 @@ import (
 const (
 	apiBaseURL             = "http://test.api.ft.com"
 	testDefaultIndex       = "test-index"
-	testExtendedIndex      = "test-extended-index"
 	esGenreType            = "genres"
 	esBrandType            = "brands"
 	esPeopleType           = "people"
@@ -34,7 +33,6 @@ const (
 	ftLocationType         = "http://www.ft.com/ontology/Location"
 	ftTopicType            = "http://www.ft.com/ontology/Topic"
 	ftAlphavilleSeriesType = "http://www.ft.com/ontology/AlphavilleSeries"
-	ftPublicCompanies      = "http://www.ft.com/ontology/company/PublicCompany"
 	testMappingFile        = "test/mapping.json"
 )
 
@@ -88,8 +86,6 @@ func (s *EsConceptSearchServiceTestSuite) SetupSuite() {
 	require.NoError(s.T(), err, "expected no error in adding topics")
 	err = writeTestConcepts(s.ec, esAlphavilleSeriesType, ftAlphavilleSeriesType, 1)
 	require.NoError(s.T(), err, "expected no error in adding topics")
-	err = writeTestConcepts(s.ec, esOrganisationType, ftPublicCompanies, 4)
-	require.NoError(s.T(), err, "expected no error in adding public companies")
 }
 
 func (s *EsConceptSearchServiceTestSuite) TearDownSuite() {
@@ -390,25 +386,6 @@ func (s *EsConceptSearchServiceTestSuite) TestFindAllConceptsByTypeDeprecatedFla
 	assert.Equal(s.T(), 1, deprecatedConceptsFound, "expect found concepts")
 
 	cleanup(s.T(), s.ec, esPeopleType, uuid)
-}
-
-func (s *EsConceptSearchServiceTestSuite) TestFindAllConceptsByDirectType() {
-	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
-	service.SetElasticClient(s.ec)
-
-	concepts, err := service.FindAllConceptsByDirectType(ftPublicCompanies, false, false)
-
-	assert.NoError(s.T(), err, "expected no error for ES read")
-	assert.Len(s.T(), concepts, 3, "there should be four public companies")
-
-	var prev string
-	for i := range concepts {
-		if i > 0 {
-			assert.Equal(s.T(), -1, strings.Compare(prev, concepts[i].PrefLabel), "concepts should be ordered")
-		}
-		assert.Equal(s.T(), ftPublicCompanies, concepts[i].ConceptType, "Results should be of type PublicCompany")
-		prev = concepts[i].PrefLabel
-	}
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypes() {

--- a/service/search_test.go
+++ b/service/search_test.go
@@ -44,7 +44,7 @@ func TestNoElasticClient(t *testing.T) {
 	_, err := service.FindAllConceptsByType(ftGenreType, false, true)
 	assert.EqualError(t, err, util.ErrNoElasticClient.Error(), "error response")
 
-	_, err = service.SearchConceptByTextAndTypes("lucy", []string{ftBrandType}, true)
+	_, err = service.SearchConceptByTextAndTypes("lucy", []string{ftBrandType}, false, true)
 	assert.EqualError(t, err, util.ErrNoElasticClient.Error(), "error response")
 }
 
@@ -419,7 +419,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypes() {
 	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
-	concepts, err := service.SearchConceptByTextAndTypes("test", []string{ftPeopleType}, true)
+	concepts, err := service.SearchConceptByTextAndTypes("test", []string{ftPeopleType}, false, true)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), concepts, 8)
 
@@ -432,7 +432,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesMultipl
 	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
-	concepts, err := service.SearchConceptByTextAndTypes("test", []string{ftBrandType, ftAlphavilleSeriesType}, true)
+	concepts, err := service.SearchConceptByTextAndTypes("test", []string{ftBrandType, ftAlphavilleSeriesType}, false, true)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), concepts, 5)
 
@@ -445,7 +445,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesNoText(
 	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
-	_, err := service.SearchConceptByTextAndTypes("", []string{ftPeopleType}, true)
+	_, err := service.SearchConceptByTextAndTypes("", []string{ftPeopleType}, false, true)
 	assert.EqualError(s.T(), err, errEmptyTextParameter.Error())
 }
 
@@ -569,7 +569,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesNoConce
 	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
-	_, err := service.SearchConceptByTextAndTypes("pippo", []string{}, true)
+	_, err := service.SearchConceptByTextAndTypes("pippo", []string{}, false, true)
 	assert.EqualError(s.T(), err, util.ErrNoConceptTypeParameter.Error())
 }
 
@@ -577,7 +577,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesInvalid
 	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
-	_, err := service.SearchConceptByTextAndTypes("pippo", []string{"http://www.ft.com/ontology/Foo"}, true)
+	_, err := service.SearchConceptByTextAndTypes("pippo", []string{"http://www.ft.com/ontology/Foo"}, false, true)
 	assert.EqualError(s.T(), err, fmt.Sprintf(util.ErrInvalidConceptTypeFormat, "http://www.ft.com/ontology/Foo"))
 }
 
@@ -596,7 +596,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesTermMat
 	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
-	concepts, err := service.SearchConceptByTextAndTypes("donald trump", []string{ftPeopleType}, true)
+	concepts, err := service.SearchConceptByTextAndTypes("donald trump", []string{ftPeopleType}, false, true)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), concepts, 2)
 
@@ -623,7 +623,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesExactMa
 	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
-	concepts, err := service.SearchConceptByTextAndTypes("new york", []string{ftLocationType}, true)
+	concepts, err := service.SearchConceptByTextAndTypes("new york", []string{ftLocationType}, false, true)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), concepts, 2)
 
@@ -650,7 +650,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesExactMa
 	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
-	concepts, err := service.SearchConceptByTextAndTypes("new yor", []string{ftLocationType}, true)
+	concepts, err := service.SearchConceptByTextAndTypes("new yor", []string{ftLocationType}, false, true)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), concepts, 2)
 
@@ -685,7 +685,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesDepreca
 	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
-	concepts, err := service.SearchConceptByTextAndTypes("new york", []string{ftLocationType}, true)
+	concepts, err := service.SearchConceptByTextAndTypes("new york", []string{ftLocationType}, false, true)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), concepts, 2)
 
@@ -695,7 +695,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesDepreca
 	assert.Equal(s.T(), "New York", nyc.PrefLabel, "Failure could indicate that the wrong concept had the higher boost")
 	assert.Equal(s.T(), "New York Deprecated", nycDeprecated.PrefLabel, "Failure could indicate that the wrong concept had the higher boost")
 
-	concepts, err = service.SearchConceptByTextAndTypes("new york", []string{ftLocationType}, false)
+	concepts, err = service.SearchConceptByTextAndTypes("new york", []string{ftLocationType}, false, false)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), concepts, 1)
 
@@ -725,7 +725,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithAut
 	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
-	concepts, err := service.SearchConceptByTextAndTypesWithBoost("robert shrimpley", []string{ftPeopleType}, "authors", true)
+	concepts, err := service.SearchConceptByTextAndTypesWithBoost("robert shrimpley", []string{ftPeopleType}, "authors", false, true)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), concepts, 3)
 
@@ -763,7 +763,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearch__SpecificTypesAreBoosted() 
 	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
-	concepts, err := service.SearchConceptByTextAndTypes("Fannie Mae", []string{ftPeopleType, ftTopicType, ftLocationType, ftOrganisationType}, true)
+	concepts, err := service.SearchConceptByTextAndTypes("Fannie Mae", []string{ftPeopleType, ftTopicType, ftLocationType, ftOrganisationType}, false, true)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), concepts, 4)
 
@@ -816,7 +816,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithAut
 	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
-	conceptsWithDeprecated, err := service.SearchConceptByTextAndTypesWithBoost("robert shrimpley", []string{ftPeopleType}, "authors", true)
+	conceptsWithDeprecated, err := service.SearchConceptByTextAndTypesWithBoost("robert shrimpley", []string{ftPeopleType}, "authors", false, true)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), conceptsWithDeprecated, 4)
 
@@ -830,7 +830,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithAut
 	assert.Equal(s.T(), "Robert Real Shrimpley", theRealEditor.PrefLabel)
 	assert.Equal(s.T(), "Roberto Shrimpley", theFake.PrefLabel)
 
-	conceptsWithoutDeprecated, err := service.SearchConceptByTextAndTypesWithBoost("robert shrimpley", []string{ftPeopleType}, "authors", false)
+	conceptsWithoutDeprecated, err := service.SearchConceptByTextAndTypesWithBoost("robert shrimpley", []string{ftPeopleType}, "authors", false, false)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), conceptsWithoutDeprecated, 3)
 
@@ -860,7 +860,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByExactMatchAliases(
 	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
-	concepts, err := service.SearchConceptByTextAndTypes("USA", []string{ftLocationType}, true)
+	concepts, err := service.SearchConceptByTextAndTypes("USA", []string{ftLocationType}, false, true)
 	require.NoError(s.T(), err)
 	require.Len(s.T(), concepts, 2)
 
@@ -876,7 +876,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoo
 	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 1, 2)
 	service.SetElasticClient(s.ec)
 
-	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{ftPeopleType}, "authors", true)
+	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{ftPeopleType}, "authors", false, true)
 	assert.NoError(s.T(), err, "expected no error for ES read")
 	assert.Len(s.T(), concepts, 1, "there should be one results")
 }
@@ -885,7 +885,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoo
 	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
-	concepts, err := service.SearchConceptByTextAndTypesWithBoost("", []string{ftPeopleType}, "authors", true)
+	concepts, err := service.SearchConceptByTextAndTypesWithBoost("", []string{ftPeopleType}, "authors", false, true)
 	assert.EqualError(s.T(), err, errEmptyTextParameter.Error())
 	assert.Nil(s.T(), concepts)
 }
@@ -894,7 +894,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoo
 	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
-	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{}, "authors", true)
+	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{}, "authors", false, true)
 	assert.EqualError(s.T(), err, util.ErrNoConceptTypeParameter.Error())
 	assert.Nil(s.T(), concepts)
 }
@@ -903,7 +903,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoo
 	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
-	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{ftPeopleType, ftLocationType}, "authors", true)
+	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{ftPeopleType, ftLocationType}, "authors", false, true)
 	assert.EqualError(s.T(), err, util.ErrNotSupportedCombinationOfConceptTypes.Error())
 	assert.Nil(s.T(), concepts)
 }
@@ -912,7 +912,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithInv
 	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)
 
-	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{ftPeopleType}, "pluto", true)
+	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{ftPeopleType}, "pluto", false, true)
 	assert.EqualError(s.T(), err, util.ErrInvalidBoostTypeParameter.Error())
 	assert.Nil(s.T(), concepts)
 }
@@ -920,7 +920,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithInv
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoostNoESConnection() {
 	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 
-	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{ftPeopleType}, "authors", true)
+	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{ftPeopleType}, "authors", false, true)
 	assert.EqualError(s.T(), err, util.ErrNoElasticClient.Error())
 	assert.Nil(s.T(), concepts)
 }
@@ -928,7 +928,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoo
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoostInvalidConceptType() {
 	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 
-	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{ftGenreType}, "authors", true)
+	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{ftGenreType}, "authors", false, true)
 	assert.EqualError(s.T(), err, fmt.Sprintf(util.ErrInvalidConceptTypeFormat, ftGenreType))
 	assert.Nil(s.T(), concepts)
 }
@@ -948,7 +948,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByPopularity() {
 	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
-	concepts, err := service.SearchConceptByTextAndTypes("USA", []string{ftLocationType}, true)
+	concepts, err := service.SearchConceptByTextAndTypes("USA", []string{ftLocationType}, false, true)
 	require.NoError(s.T(), err)
 	require.Len(s.T(), concepts, 2)
 
@@ -975,7 +975,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByPopularityAliasMat
 	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
-	concepts, err := service.SearchConceptByTextAndTypes("Dr G", []string{ftLocationType}, true)
+	concepts, err := service.SearchConceptByTextAndTypes("Dr G", []string{ftLocationType}, false, true)
 	require.NoError(s.T(), err)
 	require.Len(s.T(), concepts, 2)
 
@@ -1002,7 +1002,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByRecentPopularitySa
 	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
-	concepts, err := service.SearchConceptByTextAndTypes("USA", []string{ftLocationType}, true)
+	concepts, err := service.SearchConceptByTextAndTypes("USA", []string{ftLocationType}, false, true)
 	require.NoError(s.T(), err)
 	require.Len(s.T(), concepts, 2)
 
@@ -1029,7 +1029,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByRecentPopularityNo
 	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
-	concepts, err := service.SearchConceptByTextAndTypes("USA", []string{ftLocationType}, true)
+	concepts, err := service.SearchConceptByTextAndTypes("USA", []string{ftLocationType}, false, true)
 	require.NoError(s.T(), err)
 	require.Len(s.T(), concepts, 2)
 
@@ -1056,7 +1056,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByRecentPopularity()
 	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
-	concepts, err := service.SearchConceptByTextAndTypes("USA", []string{ftLocationType}, true)
+	concepts, err := service.SearchConceptByTextAndTypes("USA", []string{ftLocationType}, false, true)
 	require.NoError(s.T(), err)
 	require.Len(s.T(), concepts, 2)
 
@@ -1083,7 +1083,7 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByAliasPartialMatch(
 	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
-	concepts, err := service.SearchConceptByTextAndTypes("roose", []string{ftLocationType}, true)
+	concepts, err := service.SearchConceptByTextAndTypes("roose", []string{ftLocationType}, false, true)
 	require.NoError(s.T(), err)
 	require.Len(s.T(), concepts, 1)
 
@@ -1104,7 +1104,7 @@ func (s *EsConceptSearchServiceTestSuite) TestFindOrganisationWithCountryCodeAnd
 	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
 	require.NoError(s.T(), err)
 
-	concepts, err := service.SearchConceptByTextAndTypes("Moo", []string{ftOrganisationType}, false)
+	concepts, err := service.SearchConceptByTextAndTypes("Moo", []string{ftOrganisationType}, false, false)
 	require.NoError(s.T(), err)
 	require.Len(s.T(), concepts, 1)
 

--- a/service_test.go
+++ b/service_test.go
@@ -94,6 +94,23 @@ func TestConceptFinder(t *testing.T) {
 		},
 		{
 			client: mockClient{
+				queryResponse: validResponse,
+			},
+			returnCode:    http.StatusOK,
+			requestURL:    requestURLWithAllAuthorities,
+			requestBody:   validRequestBody,
+			expectedUUIDs: []string{"9a0dd8b8-2ae4-34ca-8639-cfef69711eb9", "6084734d-f4c2-3375-b298-dbbc6c00a680"},
+			assertFields: map[string]func(concept){
+				"9a0dd8b8-2ae4-34ca-8639-cfef69711eb9": func(c concept) {
+					assert.Equal(t, "Foobar SpA", c.PrefLabel)
+					assert.Equal(t, "", c.ScopeNote)
+					assert.Equal(t, "http://www.ft.com/ontology/company/PublicCompany", c.DirectType)
+					assert.Equal(t, "CA", c.CountryCode)
+					assert.Equal(t, "US", c.CountryOfIncorporation)
+				}},
+		},
+		{
+			client: mockClient{
 				queryResponse: invalidResponseBadHits,
 			},
 			returnCode:  http.StatusInternalServerError,
@@ -626,14 +643,17 @@ func (mc mockClient) getClusterHealth() (*elastic.ClusterHealthResponse, error) 
 	return &elastic.ClusterHealthResponse{}, nil
 }
 
-const validRequestBody = `{"term":"Foobar"}`
-const validRequestBodyForDeprecated = `{"term": "Rick And Morty"}`
-const invalidRequestBody = `{"term":"Foobar}`
-const missingTermRequestBody = `{"ter":"Foobar"}`
+const (
+	validRequestBody              = `{"term":"Foobar"}`
+	validRequestBodyForDeprecated = `{"term": "Rick And Morty"}`
+	invalidRequestBody            = `{"term":"Foobar}`
+	missingTermRequestBody        = `{"ter":"Foobar"}`
 
-const defaultRequestURL = "http://nothing/at/all"
-const requestURLWithScore = "http://nothing/at/all?include_score=true"
-const requestURLWithScoreAndDeprecated = "http://nothing/at/all?include_score=true&include_deprecated=true"
+	defaultRequestURL                = "http://nothing/at/all"
+	requestURLWithScore              = "http://nothing/at/all?include_score=true"
+	requestURLWithScoreAndDeprecated = "http://nothing/at/all?include_score=true&include_deprecated=true"
+	requestURLWithAllAuthorities     = "http://nothing/at/all?searchAllAuthorities=true"
+)
 
 const validResponse = `{
   "took": 111,

--- a/service_test.go
+++ b/service_test.go
@@ -56,8 +56,7 @@ func TestConceptFinder(t *testing.T) {
 			requestBody:   validRequestBody,
 			expectedUUIDs: []string{"9a0dd8b8-2ae4-34ca-8639-cfef69711eb9", "6084734d-f4c2-3375-b298-dbbc6c00a680"},
 			assertFields: map[string]func(concept){
-				"9a0dd8b8-2ae4-34ca-8639-cfef69711eb9":
-				func(c concept) {
+				"9a0dd8b8-2ae4-34ca-8639-cfef69711eb9": func(c concept) {
 					assert.Equal(t, "Foobar SpA", c.PrefLabel)
 					assert.Equal(t, "", c.ScopeNote)
 					assert.Equal(t, "http://www.ft.com/ontology/company/PublicCompany", c.DirectType)
@@ -119,7 +118,7 @@ func TestConceptFinder(t *testing.T) {
 
 	for _, testCase := range testCases {
 		conceptFinder := &esConceptFinder{
-			indexName:         "concept",
+			defaultIndex:      "concept",
 			searchResultLimit: 50,
 			lockClient:        &sync.RWMutex{},
 		}
@@ -340,7 +339,7 @@ func TestConceptFinderForBestMatch(t *testing.T) {
 
 	for _, testCase := range testCases {
 		conceptFinder := &esConceptFinder{
-			indexName:         "concept",
+			defaultIndex:      "concept",
 			searchResultLimit: 50,
 			lockClient:        &sync.RWMutex{},
 		}
@@ -403,7 +402,7 @@ func TestEsQueryScore(t *testing.T) {
 	// prepare request and trigger this
 	req, _ := http.NewRequest("POST", "http://dummy_host/concepts?include_score=true", strings.NewReader(`{"term": "Anna"}`))
 	w := httptest.NewRecorder()
-	conceptFinder := newConceptFinder(filterScoreTestingIndexName, 10)
+	conceptFinder := newConceptFinder(filterScoreTestingIndexName, "", 10)
 	conceptFinder.SetElasticClient(ec)
 	conceptFinder.FindConcept(w, req)
 
@@ -452,7 +451,7 @@ func TestEsBestMatchImpl(t *testing.T) {
 			"conceptTypes": ["http://www.ft.com/ontology/person/Person"]
 		}`))
 	w := httptest.NewRecorder()
-	conceptFinder := newConceptFinder(bestMatchIndexName, 10)
+	conceptFinder := newConceptFinder(bestMatchIndexName, "", 10)
 	conceptFinder.SetElasticClient(ec)
 	conceptFinder.FindConcept(w, req)
 

--- a/util/data.go
+++ b/util/data.go
@@ -14,7 +14,7 @@ var (
 		"http://www.ft.com/ontology/Location":                  "locations",
 		"http://www.ft.com/ontology/Topic":                     "topics",
 		"http://www.ft.com/ontology/AlphavilleSeries":          "alphaville-series",
-		"http://www.ft.com/ontology/company/PublicCompany":     "public-company",
+		"http://www.ft.com/ontology/company/PublicCompany":     "organisations",
 	}
 
 	ErrInvalidConceptTypeFormat              = "invalid concept type %v"

--- a/util/data.go
+++ b/util/data.go
@@ -14,6 +14,7 @@ var (
 		"http://www.ft.com/ontology/Location":                  "locations",
 		"http://www.ft.com/ontology/Topic":                     "topics",
 		"http://www.ft.com/ontology/AlphavilleSeries":          "alphaville-series",
+		"http://www.ft.com/ontology/company/PublicCompany":     "public-company",
 	}
 
 	ErrInvalidConceptTypeFormat              = "invalid concept type %v"


### PR DESCRIPTION
- Providing the possibility for clients to specify the http parameter `type` with the value "http://www.ft.com/ontology/company/PublicCompany". 

- Extend the search domain by using the `searchAllAuthorities` flag which will include results from Factset authority
