### PR TITLE
Updated query when searching by PublicCompany and text

### DIFF
--- a/service.go
+++ b/service.go
@@ -280,7 +280,7 @@ func createSearchRequestsForBestMatch(request *http.Request, criteria *searchCri
 
 		// filter for given concept types
 		if len(criteria.ConceptTypes) > 0 {
-			esTypes, err := util.ValidateAndConvertToEsTypes(criteria.ConceptTypes)
+			esTypes, _, err := util.ValidateAndConvertToEsTypes(criteria.ConceptTypes)
 			if err != nil {
 				return nil, http.StatusBadRequest, err
 			}

--- a/service/search_test.go
+++ b/service/search_test.go
@@ -441,6 +441,32 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesMultipl
 	}
 }
 
+func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesPublicCompanies() {
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
+	service.SetElasticClient(s.ec)
+
+	concepts, err := service.SearchConceptByTextAndTypes("test", []string{ftPublicCompanies}, false, true)
+	assert.NoError(s.T(), err)
+	assert.Len(s.T(), concepts, 4)
+
+	for _, concept := range concepts {
+		assert.True(s.T(), concept.ConceptType == ftPublicCompanies, "expect concept to have type PublicCompany")
+	}
+}
+
+func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesMultipleTypesWithPublicCompanies() {
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
+	service.SetElasticClient(s.ec)
+
+	concepts, err := service.SearchConceptByTextAndTypes("test", []string{ftBrandType, ftPublicCompanies}, false, true)
+	assert.NoError(s.T(), err)
+	assert.Len(s.T(), concepts, 8)
+
+	for _, concept := range concepts {
+		assert.True(s.T(), concept.ConceptType == ftBrandType || concept.ConceptType == ftPublicCompanies, "expect concept to be either brand or public company")
+	}
+}
+
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesNoText() {
 	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 2)
 	service.SetElasticClient(s.ec)

--- a/util/data.go
+++ b/util/data.go
@@ -5,6 +5,10 @@ import (
 	"fmt"
 )
 
+const (
+	PublicCompany = "http://www.ft.com/ontology/company/PublicCompany"
+)
+
 var (
 	esTypeMapping = map[string]string{
 		"http://www.ft.com/ontology/Genre":                     "genres",
@@ -14,7 +18,6 @@ var (
 		"http://www.ft.com/ontology/Location":                  "locations",
 		"http://www.ft.com/ontology/Topic":                     "topics",
 		"http://www.ft.com/ontology/AlphavilleSeries":          "alphaville-series",
-		"http://www.ft.com/ontology/company/PublicCompany":     "organisations",
 	}
 
 	ErrInvalidConceptTypeFormat              = "invalid concept type %v"
@@ -72,16 +75,22 @@ func ValidateForAuthorsSearch(conceptTypes []string, boostType string) error {
 	return nil
 }
 
-func ValidateAndConvertToEsTypes(conceptTypes []string) ([]string, error) {
+func ValidateAndConvertToEsTypes(conceptTypes []string) ([]string, bool, error) {
 	esTypes := make([]string, len(conceptTypes))
+	isPublicCompany := false
+
 	for _, t := range conceptTypes {
+		if t == PublicCompany {
+			isPublicCompany = true
+			continue
+		}
 		esT := EsType(t)
 		if esT == "" {
-			return esTypes, NewInputErrorf(ErrInvalidConceptTypeFormat, t)
+			return esTypes, false, NewInputErrorf(ErrInvalidConceptTypeFormat, t)
 		}
 		esTypes = append(esTypes, esT)
 	}
-	return esTypes, nil
+	return esTypes, isPublicCompany, nil
 }
 
 type InputError struct {

--- a/util/data_test.go
+++ b/util/data_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,13 +34,28 @@ func TestValidateAuthors(t *testing.T) {
 	assert.Nil(t, ValidateForAuthorsSearch([]string{"http://www.ft.com/ontology/person/Person"}, "authors"))
 }
 
-func TestValidateEsTypes(t *testing.T) {
-	res, err := ValidateAndConvertToEsTypes([]string{"http://www.ft.com/ontology/Foo", "http://www.ft.com/ontology/person/Person"})
-	assert.Contains(t, err.Error(), "http://www.ft.com/ontology/Foo")
-
-	res, err = ValidateAndConvertToEsTypes([]string{"http://www.ft.com/ontology/person/Person"})
+func TestValidateEsTypesNoError(t *testing.T) {
+	res, isPublicCompany, err := ValidateAndConvertToEsTypes([]string{"http://www.ft.com/ontology/person/Person"})
 	assert.NoError(t, err)
 	assert.Len(t, res, 2)
 	assert.Equal(t, "", res[0])
 	assert.Equal(t, "people", res[1])
+	assert.Equal(t, false, isPublicCompany)
+}
+
+func TestValidateEsTypesReturnError(t *testing.T) {
+	_, isPublicCompany, err := ValidateAndConvertToEsTypes([]string{"http://www.ft.com/ontology/Foo", "http://www.ft.com/ontology/person/Person"})
+	assert.Contains(t, err.Error(), "http://www.ft.com/ontology/Foo")
+	assert.Equal(t, false, isPublicCompany)
+}
+
+func TestValidateEsTypesWithPublicCompany(t *testing.T) {
+	res, isPublicCompany, err := ValidateAndConvertToEsTypes([]string{"http://www.ft.com/ontology/person/Person", "http://www.ft.com/ontology/company/PublicCompany"})
+	fmt.Printf("%v", res)
+	assert.NoError(t, err)
+	assert.Len(t, res, 3)
+	assert.Equal(t, "", res[0])
+	assert.Equal(t, "", res[1])
+	assert.Equal(t, "people", res[2])
+	assert.Equal(t, true, isPublicCompany)
 }


### PR DESCRIPTION
- Problem: 
GET `__concept-search-api/concepts?type=http://www.ft.com/ontology/company/PublicCompany&mode=search&q=Buff&searchAllAuthorities=true` returns concepts of type Organization. Some of them happens to be public companies, but some of them are not.
- Fix: update the elastic search query to look for both `_type` and `directType` fields.