### PR TITLE
fix nodejs version for dredd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,9 @@ jobs:
       - run:
           name: Download dredd
           command: |
-            curl -sL https://deb.nodesource.com/setup_11.x | bash -
-            DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs=11.\*
-            npm install -g --unsafe-perm --loglevel warn --user 0 --no-progress dredd@8.0.0
+            curl -sL https://deb.nodesource.com/setup_16.x | bash -
+            DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs=16.\*
+            npm install -g --unsafe-perm --loglevel warn --user 0 --no-progress dredd@14.0.*
             rm -rf /var/lib/apt/lists/*
       - run:
           name: Dredd API Testing

--- a/dredd.yml
+++ b/dredd.yml
@@ -1,7 +1,6 @@
 dry-run: null
 hookfiles: './_ft/dredd-setup-es-hook.js'
 language: nodejs
-sandbox: false
 server: ./concept-search-api
 server-wait: 3
 init: false
@@ -17,9 +16,7 @@ inline-errors: false
 details: false
 method: []
 color: true
-level: info
-timestamp: false
-silent: false
+loglevel: warning
 path: []
 hooks-worker-timeout: 5000
 hooks-worker-connect-timeout: 1500


### PR DESCRIPTION
# Description

## What

The version of dredd is updated to the latest available one in order to support OpenAPI v3 for the needs of the API testing.

## Why

API tests are not running right now

## Anything, in particular, you'd like to highlight to reviewers

The changes are just enabling dredd, some of the tests are still falling. 

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
