### PR TITLE
Fix/tests running

### DIFF
--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -7,7 +7,7 @@ services:
     container_name: test-runner
     environment:
       - ELASTICSEARCH_TEST_URL=http://elasticsearch:9200
-    command: ["go", "test", "-mod=readonly", "-v", "-race", "./..."]
+    command: ["go", "test", "-mod=readonly", "-v", "-race", "-tags=integration", "./..."]
     depends_on:
       - elasticsearch
   elasticsearch:

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -14,3 +14,5 @@ services:
     image: elasticsearch:5.3
     ports:
       - "9201:9200"
+    environment:
+      ES_JAVA_OPTS: "-Xms750m -Xmx750m"

--- a/service/search_test.go
+++ b/service/search_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package service
 
 import (

--- a/service_test.go
+++ b/service_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package main
 
 import (


### PR DESCRIPTION
# Description

## What

Improve integration tests set up by:
- separating the unit and integration tests execution via build flags;
- add java environment restrictions to the ElasticSearch image in the integration tests to restrict memory consumption;

## Why

Collaboration with the Search&Recommendations team.

## Scope and particulars of this PR (Please tick all that apply)

- [X] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [X] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
