### PR TITLE
SNR-128 Implement text search for 1st party data initiative

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,12 @@ curl {concept-search-api-url}/concepts?type=http://www.ft.com/ontology/Genre
 ```
 
 Optional query parameters:
-- To activate the search mode, you can send the `mode` parameter with the value `search`, and `q` parameter with the value of the search query
-	```
-	curl {concept-search-api-url}/concepts?type=http://www.ft.com/ontology/organisation/Organisation&mode=search&q=FOO
-	```
+- To activate the search mode, you can send the `mode` parameter with the values described in the table below, and `q` parameter with the value of the search query
+
+| Mode          | Description                                                                                                                                                                                                                                                                                                                                                                           |
+|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `mode=search` | Optimized for time-sensitive types such as topics, people <br> ``` curl {concept-search-api-url}/concepts?type=http://www.ft.com/ontology/organisation/Organisation&mode=search&q=FOO ```                                                                                                                                                                                             |
+| `mode=text`   | Optimized for types that are not time-sensitive. Uses full-text ES queries.  **Note: Currently requests are possible only if either organization or public company type is supplied to the request** <br> ``` curl {concept-search-api-url}/concepts?type=http://www.ft.com/ontology/organisation/Organisation&type=http://www.ft.com/ontology/company/PublicCompany&mode=text&q=FOO ``` |
 - `boost` parameter can be specified when activating  the search mode, but it is currently supported only for authors
 	
 	E.g. The following request will return results with `"isFTAuthor": true`

--- a/resources/handler.go
+++ b/resources/handler.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/Financial-Times/concept-search-api/util"
 
+	"strings"
+
 	"github.com/Financial-Times/concept-search-api/service"
 	"gopkg.in/olivere/elastic.v5"
-	"strings"
 )
 
 type Handler struct {
@@ -36,7 +37,7 @@ func (h *Handler) ConceptSearch(w http.ResponseWriter, req *http.Request) {
 	var err error
 	var concepts []service.Concept
 
-	mode, foundMode, modeErr := util.GetSingleValueQueryParameter(req, "mode", "search")
+	mode, foundMode, modeErr := util.GetSingleValueQueryParameter(req, "mode", "search", "text")
 	q, foundQ, qErr := util.GetSingleValueQueryParameter(req, "q")
 	conceptTypes, foundConceptTypes := util.GetMultipleValueQueryParameter(req, "type")
 	boostType, foundBoostType, boostTypeErr := util.GetSingleValueQueryParameter(req, "boost") // we currently only accept authors, so ignoring the actual boost value
@@ -62,6 +63,13 @@ func (h *Handler) ConceptSearch(w http.ResponseWriter, req *http.Request) {
 			} else {
 				if mode == "search" {
 					concepts, err = h.searchConcepts(foundBoostType, boostType, foundQ, q, conceptTypes, searchAllAuthorities, includeDeprecated)
+				} else if mode == "text" {
+					validationErr := util.ValidateConceptTypesForTextModeSearch(conceptTypes)
+					if validationErr != nil {
+						err = validationErr
+					} else {
+						concepts, err = h.searchConceptsInTextMode(foundQ, q, conceptTypes, searchAllAuthorities, includeDeprecated)
+					}
 				}
 			}
 		} else {
@@ -88,7 +96,6 @@ func (h *Handler) ConceptSearch(w http.ResponseWriter, req *http.Request) {
 			if err == util.ErrNoElasticClient || err == elastic.ErrNoClient {
 				writeHTTPError(w, http.StatusServiceUnavailable, err)
 			} else {
-
 				writeHTTPError(w, http.StatusInternalServerError, err)
 			}
 		}
@@ -107,6 +114,13 @@ func (h *Handler) searchConcepts(foundBoostType bool, boostType string, foundQ b
 		return h.service.SearchConceptByTextAndTypesWithBoost(q, conceptTypes, boostType, searchAllAuthorities, includeDeprecated)
 	}
 	return h.service.SearchConceptByTextAndTypes(q, conceptTypes, searchAllAuthorities, includeDeprecated)
+}
+
+func (h *Handler) searchConceptsInTextMode(foundQ bool, q string, conceptTypes []string, searchAllAuthorities bool, includeDeprecated bool) ([]service.Concept, error) {
+	if !foundQ {
+		return nil, NewValidationError("invalid or missing parameters for concept search (require q)")
+	}
+	return h.service.SearchConceptByTextAndTypesInTextMode(q, conceptTypes, searchAllAuthorities, includeDeprecated)
 }
 
 func (h *Handler) findConceptsByType(conceptTypes []string, includeDeprecated bool, searchAllAuthorities bool) ([]service.Concept, error) {

--- a/service/search_test.go
+++ b/service/search_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package service
@@ -968,6 +969,80 @@ func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesWithBoo
 	concepts, err := service.SearchConceptByTextAndTypesWithBoost("test", []string{ftGenreType}, "authors", false, true)
 	assert.EqualError(s.T(), err, fmt.Sprintf(util.ErrInvalidConceptTypeFormat, ftGenreType))
 	assert.Nil(s.T(), concepts)
+}
+
+func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesInTextModeNoInputText() {
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 10)
+
+	concepts, err := service.SearchConceptByTextAndTypesInTextMode("", []string{ftOrganisationType}, false, true)
+	assert.EqualError(s.T(), err, errEmptyTextParameter.Error())
+	assert.Nil(s.T(), concepts)
+}
+
+func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesInTextModeNoTypes() {
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 10)
+	service.SetElasticClient(s.ec)
+
+	concepts, err := service.SearchConceptByTextAndTypesInTextMode("test", []string{}, false, true)
+	assert.EqualError(s.T(), err, util.ErrNoConceptTypeParameter.Error())
+	assert.Nil(s.T(), concepts)
+}
+
+func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesInTextMode() {
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 10)
+	service.SetElasticClient(s.ec)
+
+	uuid1 := uuid.New().String()
+	err := writeTestConcept(s.ec, uuid1, esOrganisationType, ftOrganisationType, "Google Inc", []string{"Google LLC"}, &ConceptMetrics{PrevWeekAnnotationsCount: 0, AnnotationsCount: 0}) // In text mode the annotations count is irrelevant
+	require.NoError(s.T(), err)
+
+	uuid2 := uuid.New().String()
+	err = writeTestConcept(s.ec, uuid2, esOrganisationType, ftOrganisationType, "Netflix Inc", []string{"NetFlix.com Inc"}, &ConceptMetrics{PrevWeekAnnotationsCount: 0, AnnotationsCount: 0})
+	require.NoError(s.T(), err)
+
+	uuid3 := uuid.New().String()
+	err = writeTestConcept(s.ec, uuid3, esOrganisationType, ftOrganisationType, "Google Ventures", []string{"GV Management"}, &ConceptMetrics{PrevWeekAnnotationsCount: 0, AnnotationsCount: 0})
+	require.NoError(s.T(), err)
+
+	_, err = s.ec.Refresh(testDefaultIndex).Do(context.Background())
+	require.NoError(s.T(), err)
+
+	concepts, err := service.SearchConceptByTextAndTypesInTextMode("Google", []string{ftOrganisationType}, false, false)
+	require.NoError(s.T(), err)
+	require.Len(s.T(), concepts, 2)
+
+	firstChoiceSearchResult := concepts[0]
+	secondChoiceSearchResult := concepts[1]
+
+	assert.Equal(s.T(), "Google Inc", firstChoiceSearchResult.PrefLabel)
+	assert.Equal(s.T(), "Google Ventures", secondChoiceSearchResult.PrefLabel)
+	cleanup(s.T(), s.ec, esOrganisationType, uuid1, uuid2, uuid3)
+}
+
+func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesInTextModePublicCompanies() {
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 10)
+	service.SetElasticClient(s.ec)
+
+	concepts, err := service.SearchConceptByTextAndTypesInTextMode("test", []string{ftPublicCompanies}, false, true)
+	assert.NoError(s.T(), err)
+	assert.Len(s.T(), concepts, 4)
+
+	for _, concept := range concepts {
+		assert.True(s.T(), concept.ConceptType == ftPublicCompanies, "expect concept to have type PublicCompany")
+	}
+}
+
+func (s *EsConceptSearchServiceTestSuite) TestSearchConceptByTextAndTypesMultipleTypesInTextModeWithPublicCompanies() {
+	service := NewEsConceptSearchService(testDefaultIndex, "", 10, 10, 10)
+	service.SetElasticClient(s.ec)
+
+	concepts, err := service.SearchConceptByTextAndTypesInTextMode("test", []string{ftBrandType, ftPublicCompanies}, false, true)
+	assert.NoError(s.T(), err)
+	assert.Len(s.T(), concepts, 8)
+
+	for _, concept := range concepts {
+		assert.True(s.T(), concept.ConceptType == ftBrandType || concept.ConceptType == ftPublicCompanies, "expect concept to be either brand or public company")
+	}
 }
 
 func (s *EsConceptSearchServiceTestSuite) TestSearchConceptsByPopularity() {

--- a/service_test.go
+++ b/service_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package main

--- a/service_test.go
+++ b/service_test.go
@@ -251,13 +251,13 @@ func TestConceptFinderForBestMatch(t *testing.T) {
 			requestURL:  defaultRequestURL,
 			requestBody: `{"bestMatchTerms":["Adam Samson", "Eric Platt", "Michael Hunter"], "conceptTypes": ["http://www.ft.com/ontology/person/Person"]}`,
 			expectedUUIDs: map[string][]string{
-				"Adam Samson": []string{
+				"Adam Samson": {
 					"f758ef56-c40a-3162-91aa-3e8a3aabc494",
 				},
-				"Eric Platt": []string{
+				"Eric Platt": {
 					"40281396-8369-4699-ae48-1ccc0c931a72",
 				},
-				"Michael Hunter": []string{
+				"Michael Hunter": {
 					"9332270e-f959-3f55-9153-d30acd0d0a51",
 				},
 			},
@@ -279,11 +279,11 @@ func TestConceptFinderForBestMatch(t *testing.T) {
 			requestURL:  defaultRequestURL,
 			requestBody: `{"bestMatchTerms":["Adam Samson", "Eric Platt", "Michael Hunter"], "conceptTypes": ["http://www.ft.com/ontology/person/Person"]}`,
 			expectedUUIDs: map[string][]string{
-				"Adam Samson": []string{
+				"Adam Samson": {
 					"f758ef56-c40a-3162-91aa-3e8a3aabc494",
 				},
-				"Eric Platt": []string{},
-				"Michael Hunter": []string{
+				"Eric Platt": {},
+				"Michael Hunter": {
 					"9332270e-f959-3f55-9153-d30acd0d0a51",
 				},
 			},
@@ -305,9 +305,9 @@ func TestConceptFinderForBestMatch(t *testing.T) {
 			requestURL:  defaultRequestURL,
 			requestBody: `{"bestMatchTerms":["Adam Samson", "Eric Platt", "Michael Hunter"], "conceptTypes": ["http://www.ft.com/ontology/person/Person"]}`,
 			expectedUUIDs: map[string][]string{
-				"Adam Samson":    []string{},
-				"Eric Platt":     []string{},
-				"Michael Hunter": []string{},
+				"Adam Samson":    {},
+				"Eric Platt":     {},
+				"Michael Hunter": {},
 			},
 			extraAssertionLogic: func(t *testing.T, searchResults map[string][]concept) {
 				for _, concepts := range searchResults {
@@ -327,13 +327,13 @@ func TestConceptFinderForBestMatch(t *testing.T) {
 			requestURL:  defaultRequestURL + "?include_field=authors",
 			requestBody: `{"bestMatchTerms":["Adam Samson", "Eric Platt", "Michael Hunter"], "conceptTypes": ["http://www.ft.com/ontology/person/Person"]}`,
 			expectedUUIDs: map[string][]string{
-				"Adam Samson": []string{
+				"Adam Samson": {
 					"f758ef56-c40a-3162-91aa-3e8a3aabc494",
 				},
-				"Eric Platt": []string{
+				"Eric Platt": {
 					"40281396-8369-4699-ae48-1ccc0c931a72",
 				},
-				"Michael Hunter": []string{
+				"Michael Hunter": {
 					"9332270e-f959-3f55-9153-d30acd0d0a51",
 				},
 			},

--- a/util/data.go
+++ b/util/data.go
@@ -98,7 +98,7 @@ func ValidateConceptTypesForTextModeSearch(conceptTypes []string) error {
 	validConceptTypesForTextMode := []string{"http://www.ft.com/ontology/organisation/Organisation", "http://www.ft.com/ontology/company/PublicCompany"}
 
 	for _, conceptType := range conceptTypes {
-		contains, err := Contains(validConceptTypesForTextMode, conceptType)
+		contains, err := contains(validConceptTypesForTextMode, conceptType)
 		if err != nil {
 			return err
 		}

--- a/util/data.go
+++ b/util/data.go
@@ -94,6 +94,21 @@ func ValidateAndConvertToEsTypes(conceptTypes []string) ([]string, bool, error) 
 	return esTypes, isPublicCompany, nil
 }
 
+func ValidateConceptTypesForTextModeSearch(conceptTypes []string) error {
+	validConceptTypesForTextMode := []string{"http://www.ft.com/ontology/organisation/Organisation", "http://www.ft.com/ontology/company/PublicCompany"}
+
+	for _, conceptType := range conceptTypes {
+		contains, err := Contains(validConceptTypesForTextMode, conceptType)
+		if err != nil {
+			return err
+		}
+		if contains {
+			return nil
+		}
+	}
+	return NewInputError("invalid or missing parameters for concept search (text mode but no organisation or public company type)")
+}
+
 type InputError struct {
 	msg string
 }

--- a/util/data_test.go
+++ b/util/data_test.go
@@ -59,3 +59,16 @@ func TestValidateEsTypesWithPublicCompany(t *testing.T) {
 	assert.Equal(t, "people", res[2])
 	assert.Equal(t, true, isPublicCompany)
 }
+
+func TestValidateConceptTypesForTextModeSearch(t *testing.T) {
+	validConceptTypes1 := []string{"http://www.ft.com/ontology/organisation/Organisation", "http://www.ft.com/ontology/company/PublicCompany"}
+	validConceptTypes2 := []string{"http://www.ft.com/ontology/organisation/Organisation", "http://www.ft.com/ontology/product/Brand"}
+	invalidConceptTypes1 := []string{"http://www.ft.com/ontology/person/Person"}
+	invalidConceptTypes2 := []string{}
+
+	assert.Nil(t, ValidateConceptTypesForTextModeSearch(validConceptTypes1))
+	assert.Nil(t, ValidateConceptTypesForTextModeSearch(validConceptTypes2))
+
+	assert.Error(t, ValidateConceptTypesForTextModeSearch(invalidConceptTypes1))
+	assert.Error(t, ValidateConceptTypesForTextModeSearch(invalidConceptTypes2))
+}

--- a/util/slice.go
+++ b/util/slice.go
@@ -4,10 +4,9 @@ import (
 	"errors"
 )
 
-// Contains - checks that a slice has a specific element
-func Contains(s []string, target string) (bool, error) {
+func contains(s []string, target string) (bool, error) {
 	if len(s) == 0 || len(target) == 0 {
-		return false, errors.New("invalid Contains arguments")
+		return false, errors.New("invalid contains arguments")
 	}
 	for _, element := range s {
 		if element == target {

--- a/util/slice.go
+++ b/util/slice.go
@@ -1,0 +1,18 @@
+package util
+
+import (
+	"errors"
+)
+
+// Contains - checks that a slice has a specific element
+func Contains(s []string, target string) (bool, error) {
+	if len(s) == 0 || len(target) == 0 {
+		return false, errors.New("invalid Contains arguments")
+	}
+	for _, element := range s {
+		if element == target {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/util/slice_test.go
+++ b/util/slice_test.go
@@ -27,5 +27,4 @@ func TestContains(t *testing.T) {
 		require.Equal(t, tc.expectedError, actualError)
 		assert.Equal(t, tc.expectedOutput, actualOutput)
 	}
-
 }

--- a/util/slice_test.go
+++ b/util/slice_test.go
@@ -10,15 +10,15 @@ import (
 
 func TestContains(t *testing.T) {
 	var testCases = []struct {
-		inputSlice []string
-		inputTarget string
+		inputSlice     []string
+		inputTarget    string
 		expectedOutput bool
-		expectedError error
+		expectedError  error
 	}{
-	{ inputSlice: []string{"foo", "bar"}, inputTarget: "bar", expectedOutput: true, expectedError: nil},
-	{ inputSlice: []string{"foo", "bar"}, inputTarget: "baz", expectedOutput: false, expectedError: nil},
-	{ inputSlice: []string{}, inputTarget: "baz", expectedOutput: false, expectedError: errors.New("invalid contains arguments")},
-	{ inputSlice: []string{"foo", "bar"}, inputTarget: "", expectedOutput: false, expectedError: errors.New("invalid contains arguments")},
+		{inputSlice: []string{"foo", "bar"}, inputTarget: "bar", expectedOutput: true, expectedError: nil},
+		{inputSlice: []string{"foo", "bar"}, inputTarget: "baz", expectedOutput: false, expectedError: nil},
+		{inputSlice: []string{}, inputTarget: "baz", expectedOutput: false, expectedError: errors.New("invalid contains arguments")},
+		{inputSlice: []string{"foo", "bar"}, inputTarget: "", expectedOutput: false, expectedError: errors.New("invalid contains arguments")},
 	}
 
 	for _, tc := range testCases {

--- a/util/slice_test.go
+++ b/util/slice_test.go
@@ -1,47 +1,31 @@
 package util
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestContainsPositive(t *testing.T) {
-	slice1 := []string{"foo", "bar"}
-	target := "bar"
+func TestContains(t *testing.T) {
+	var testCases = []struct {
+		inputSlice []string
+		inputTarget string
+		expectedOutput bool
+		expectedError error
+	}{
+	{ inputSlice: []string{"foo", "bar"}, inputTarget: "bar", expectedOutput: true, expectedError: nil},
+	{ inputSlice: []string{"foo", "bar"}, inputTarget: "baz", expectedOutput: false, expectedError: nil},
+	{ inputSlice: []string{}, inputTarget: "baz", expectedOutput: false, expectedError: errors.New("invalid contains arguments")},
+	{ inputSlice: []string{"foo", "bar"}, inputTarget: "", expectedOutput: false, expectedError: errors.New("invalid contains arguments")},
+	}
 
-	contains, err := contains(slice1, target)
+	for _, tc := range testCases {
+		actualOutput, actualError := contains(tc.inputSlice, tc.inputTarget)
 
-	assert.True(t, contains)
-	assert.Nil(t, err)
-}
+		require.Equal(t, tc.expectedError, actualError)
+		assert.Equal(t, tc.expectedOutput, actualOutput)
+	}
 
-func TestContainsNegative(t *testing.T) {
-	slice1 := []string{"foo", "bar"}
-	target := "baz"
-
-	contains, err := contains(slice1, target)
-
-	assert.False(t, contains)
-	assert.Nil(t, err)
-}
-
-func TestContainsEmptySlice(t *testing.T) {
-	slice1 := []string{}
-	target := "baz"
-
-	contains, err := contains(slice1, target)
-
-	assert.False(t, contains)
-	assert.Error(t, err)
-}
-
-func TestContainsEmptyString(t *testing.T) {
-	slice1 := []string{"foo", "bar"}
-	target := ""
-
-	contains, err := contains(slice1, target)
-
-	assert.False(t, contains)
-	assert.Error(t, err)
 }

--- a/util/slice_test.go
+++ b/util/slice_test.go
@@ -10,7 +10,7 @@ func TestContainsPositive(t *testing.T) {
 	slice1 := []string{"foo", "bar"}
 	target := "bar"
 
-	contains, err := Contains(slice1, target)
+	contains, err := contains(slice1, target)
 
 	assert.True(t, contains)
 	assert.Nil(t, err)
@@ -20,7 +20,7 @@ func TestContainsNegative(t *testing.T) {
 	slice1 := []string{"foo", "bar"}
 	target := "baz"
 
-	contains, err := Contains(slice1, target)
+	contains, err := contains(slice1, target)
 
 	assert.False(t, contains)
 	assert.Nil(t, err)
@@ -30,7 +30,7 @@ func TestContainsEmptySlice(t *testing.T) {
 	slice1 := []string{}
 	target := "baz"
 
-	contains, err := Contains(slice1, target)
+	contains, err := contains(slice1, target)
 
 	assert.False(t, contains)
 	assert.Error(t, err)
@@ -40,7 +40,7 @@ func TestContainsEmptyString(t *testing.T) {
 	slice1 := []string{"foo", "bar"}
 	target := ""
 
-	contains, err := Contains(slice1, target)
+	contains, err := contains(slice1, target)
 
 	assert.False(t, contains)
 	assert.Error(t, err)

--- a/util/slice_test.go
+++ b/util/slice_test.go
@@ -1,0 +1,47 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContainsPositive(t *testing.T) {
+	slice1 := []string{"foo", "bar"}
+	target := "bar"
+
+	contains, err := Contains(slice1, target)
+
+	assert.True(t, contains)
+	assert.Nil(t, err)
+}
+
+func TestContainsNegative(t *testing.T) {
+	slice1 := []string{"foo", "bar"}
+	target := "baz"
+
+	contains, err := Contains(slice1, target)
+
+	assert.False(t, contains)
+	assert.Nil(t, err)
+}
+
+func TestContainsEmptySlice(t *testing.T) {
+	slice1 := []string{}
+	target := "baz"
+
+	contains, err := Contains(slice1, target)
+
+	assert.False(t, contains)
+	assert.Error(t, err)
+}
+
+func TestContainsEmptyString(t *testing.T) {
+	slice1 := []string{"foo", "bar"}
+	target := ""
+
+	contains, err := Contains(slice1, target)
+
+	assert.False(t, contains)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
# Implement text search for 1st party data initiative
Ready for review 🔍 

This PR will add functionality to the API that accommodates typeahead search for organisations. More on the initiative:
 - [Solution Design Document](https://docs.google.com/document/d/1gg_SHFRVGS0mWo-cEj_L7cniWe8Csr733R98-RRfKSQ/edit#heading=h.s97242meid1c)
 - [JIRA link](https://financialtimes.atlassian.net/browse/SNR-35)

## What

In terms of the API, this PR adds another `mode=text` to the `/concepts` route. The current `mode=search` is optimized for recently annotated data which is not the case for some organizations and public companies. The new mode enables full-text search queries and disables optimizations for recently annotated data.

## Why

As the design document states: *In short, the end goal is to start collecting usable organization data from B2C subscribers.*

## Anything, in particular, you'd like to highlight to reviewers

Thanks to the much-needed help from @doandzhiFt, we managed to configure the ES query and get the following smudge evaluation:
```json
{
    "duration": "12m21.252076856s",
    "totalExistsInDatabase": 66,
    "totalConcepts": 68,
    "averages": {
        "averageScore": 0.4291627714869715,
        "byType": {
            "http://www.ft.com/ontology/Location": 0.1858806648021389,
            "http://www.ft.com/ontology/Topic": 0.31178079050620283,
            "http://www.ft.com/ontology/company/PublicCompany": 0.6357323550994408,
            "http://www.ft.com/ontology/organisation/Organisation": 0.5335569983216205,
            "http://www.ft.com/ontology/person/Person": 0.43816667242773083
        }
    }
}
```

❔ Any ideas on how to improve this score will be appreciated greatly.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [X] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
